### PR TITLE
Upgrade kustomize. Modernize helm manifest generation.

### DIFF
--- a/hack/install_dependencies.sh
+++ b/hack/install_dependencies.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 kubebuilder_version=2.3.1
-kustomize_version=3.8.7
+kustomize_version=4.0.5
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
@@ -14,8 +14,7 @@ GO111MODULE=on go mod tidy
 
 #Install Kustomize
 if ! (which kustomize); then
-  (cd /tmp && curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- ${kustomize_version})
-  sudo mv "/tmp/kustomize" /usr/local/bin
+  (cd /tmp && curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- ${kustomize_version} /usr/local/bin)
   echo "Installed kustomize at /usr/local/bin/kustomize, version: $(kustomize version --short)"
 else
   echo "Kustomize already installed at $(which kustomize), version: $(kustomize version --short)"

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1138,6 +1139,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6455,6 +6457,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
`make manifests` no longer relies on Kustomize. This means that our checks are not broken by inconsistencies between different versions of Kustomize.