### PR TITLE
Help for upgrading from v0.2.x to v0.3.0

### DIFF
--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -21,28 +21,85 @@ Next, install the Solr Operator chart. Note this is using Helm v3, use the offic
 This will install the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) by default.
 
 ```bash
-$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.3.0/all.yaml
+$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.3.0/all-with-dependencies.yaml
 $ helm install solr-operator apache-solr/solr-operator --version 0.3.0
 ```
+
+_Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._
+
 
 After installing, you can check to see what lives in the cluster to make sure that the Solr and ZooKeeper operators have started correctly.
 ```bash
 $ kubectl get all
 
-NAME                                              READY   STATUS             RESTARTS   AGE
-pod/solr-operator-8449d4d96f-cmf8p                1/1     Running            0          47h
-pod/zookeeper-operator-674676769c-gd4jr           1/1     Running            0          49d
+NAME                                                   READY   STATUS             RESTARTS   AGE
+pod/solr-operator-8449d4d96f-cmf8p                     1/1     Running            0          47h
+pod/solr-operator-zookeeper-operator-674676769c-gd4jr  1/1     Running            0          49d
 
 NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/solr-operator                     1/1     1            1           49d
-deployment.apps/zookeeper-operator                1/1     1            1           49d
+deployment.apps/solr-operator-zookeeper-operator  1/1     1            1           49d
 
-NAME                                              DESIRED   CURRENT   READY   AGE
-replicaset.apps/solr-operator-8449d4d96f          1         1         1       2d1h
-replicaset.apps/zookeeper-operator-674676769c     1         1         1       49d
+NAME                                                         DESIRED   CURRENT   READY   AGE
+replicaset.apps/solr-operator-8449d4d96f                     1         1         1       2d1h
+replicaset.apps/solr-operator-zookeeper-operator-674676769c  1         1         1       49d
 ```
 
 After inspecting the status of you Kube cluster, you should see a deployment for the Solr Operator as well as the Zookeeper Operator.
+
+### Managing CRDs
+
+Helm 3 automatically installs the Solr CRDs in the /crds directory, so no further action is needed when first installing the Operator.
+
+If you have solr operator installations in multiple namespaces that are managed separately, you will likely want to skip installing CRDs when installing the chart.
+This can be done with the `--skip-crds` helm option.
+
+```bash
+helm install solr-operator apache-solr/solr-operator --skip-crds --namespace solr
+```
+
+**Helm will not upgrade CRDs once they have been installed.
+Therefore, if you are upgrading from a previous Solr Operator version, be sure to install the most recent CRDs first.**
+
+You can update the released Solr CRDs with the following URL:
+```bash
+kubectl replace -f "https://solr.apache.org/operator/downloads/crds/<version>/<name>.yaml"
+```
+
+Examples:
+- `https://solr.apache.org/operator/downloads/crds/v0.3.0/all.yaml`  
+  Includes all Solr CRDs in the `v0.3.0` release
+- `https://solr.apache.org/operator/downloads/crds/v0.2.7/all-with-dependencies.yaml`  
+  Includes all Solr CRDs and dependency CRDs in the `v0.2.7` release
+- `https://solr.apache.org/operator/downloads/crds/v0.2.8/solrclouds.yaml`  
+  Just the SolrCloud CRD in the `v0.2.8` release
+
+#### The ZookeeperCluster CRD
+
+If you use the provided Zookeeper Cluster in the SolrCloud Spec, it is important to make sure you have the correct `ZookeeperCluster` CRD installed as well.
+
+The Zookeeper Operator Helm chart includes its CRDs when installing, however the way the CRDs are managed can be considered risky.
+If we let the Zookeeper Operator Helm chart manage the Zookeeper CRDs, then users could see outages when [uninstalling the chart](#uninstalling-the-chart).
+Therefore, by default, we tell the Zookeeper Operator to not install the Zookeeper CRDs.
+You can override this, assuming the risks, by setting `zookeeper-operator.crd.create: true`.
+
+For manual installation of the ZookeeperCluster CRD, you can find the file in the [zookeeper-operator repo](https://github.com/pravega/zookeeper-operator/blob/master/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml), for the correct release,
+or use the convenience download locations provided below.
+The Solr CRD releases have bundled the ZookeeperCluster CRD required in each version.
+
+```bash
+# Install all Solr CRDs as well as the dependency CRDS (ZookeeperCluster) for the given version of the Solr Operator
+kubectl create -f "https://solr.apache.org/operator/downloads/crds/<solr operator version>/all-with-dependencies.yaml"
+
+# Install just the ZookeeperCluster CRD used in the given version of the Solr Operator
+kubectl create -f "https://solr.apache.org/operator/downloads/crds/<solr operator version>/zookeeperclusters.yaml"
+```
+
+Examples:
+- `https://solr.apache.org/operator/downloads/crds/v0.3.0/all-with-dependencies.yaml`  
+  Includes all Solr CRDs and dependency CRDs, including `ZookeeperCluster`, in the `v0.3.0` Solr Operator release
+- `https://solr.apache.org/operator/downloads/crds/v0.2.8/zookeeperclusters.yaml`  
+  Just the ZookeeperCluster CRD required in the `v0.2.8` Solr Operator release
 
 ## Solr Operator Docker Images
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -26,12 +26,26 @@ Instead, you will need to manually install the CRDs whenever upgrading your Solr
 
 You can do this via the following command, replacing `<version>` with the version of the Solr Operator you are installing:
 ```bash
-kubectl replace -f http://solr.apache.org/operator/downloads/crds/<version>/all.yaml
+# Just replace the Solr CRDs
+kubectl replace -f "http://solr.apache.org/operator/downloads/crds/<version>/all.yaml"
+# Just replace the Solr CRDs and all CRDs it might depend on (e.g. ZookeeperCluster)
+kubectl replace -f "http://solr.apache.org/operator/downloads/crds/<version>/all-with-dependencies.yaml"
 ```
 
-For example, `kubectl replace -f http://solr.apache.org/operator/downloads/crds/v0.2.8/all.yaml`.
-
 It is **strongly recommended** to use `kubectl create` or `kubectl replace`, instead of `kubectl apply` when creating/updating CRDs.
+
+### Upgrading the Zookeeper Operator
+
+When upgrading the Solr Operator, you may need to upgrade the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) at the same time.
+If you are using the Solr Helm chart to deploy the Zookeeper operator, then you won't need to do anything besides installing the CRD's with dependencies, and upgrade the Solr Operator helm deployment.
+
+```bash
+# Just replace the Solr CRDs and all CRDs it might depend on (e.g. ZookeeperCluster)
+kubectl replace -f "http://solr.apache.org/operator/downloads/crds/v0.3.0/all-with-dependencies.yaml"
+helm upgrade solr-operator apache-solr/solr-operator --version 0.3.0
+```
+
+_Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._
 
 ## Upgrade Warnings and Notes
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 Please carefully read the entries for all versions between the version you are running and the version you want to upgrade to.
 
+## Upgrading from `v0.2.x` to `v0.3.x`
+If you are upgrading from `v0.2.x` to `v0.3.x`, please follow the [Upgrading to Apache guide](upgrading-to-apache.md).
+This is a special upgrade that requires different instructions.
+
 ## Upgrading minor versions (`v_.X._`)
 
 In order to upgrade minor versions (e.g. `v0.2.5` -> `v0.3.0`), you must upgrade one minor version at a time (e.g. `v0.2.0` -> `v0.3.0` -> `v0.4.0`).

--- a/docs/upgrading-to-apache.md
+++ b/docs/upgrading-to-apache.md
@@ -1,15 +1,133 @@
 # Upgrading the Solr Operator from Bloomberg to Apache
 
+Please read the guide fully before attempting to upgrade your system.
+
+## Guide
+
+There are many ways of managing what runs in your Kubernetes cluster.
+Therefore, we cannot give one definitive way of upgrading the Solr Operator and the Solr resources in your Cluster.
+
+Below are guides based on how to upgrade, depending on the type of management that you use.
+Please look through all the instructions to see what will work best for your setup.
+
+## If you manage your cluster declaratively
+
+If you have an external system managing your cluster (e.g. Ansible, Helm, etc), then the steps you take to upgrade the Solr Operator may be very different.
+
+1. Make sure your system is installing the `v0.3.0` version of the Solr Operator, through the [Helm chart](https://artifacthub.io/packages/helm/apache-solr/solr-operator), or other means.
+1. Make sure your system is [installing the `v0.2.9` version of the Zookeeper Operator](#zookeeper-operator-upgrade).
+1. Make sure the Solr resources you are installing are using the new `solr.apache.org` group and not `solr.bloomberg.com`.
+1. Check if the Solr resources you are managing use any fields deprecated in `v0.2.x` versions, you can check for these in the [Upgrade Notes](upgrade-notes.md#upgrade-warnings-and-notes).
+    - If your resources contain these fields, replace them with their new locations.
+    Otherwise, your `kubectl apply` commands will fail when using the `solr.apache.org` CRDs.
+
+Once you have made sure that your declarative system is checked for the above points, you can run it to install the new version of the Solr Operator and all of your new CRDs.
+
+Now you need to delete all the old `solr.bloomberg.com` resources & operator.
+
+1. Remove the `v0.2.x` version of the Solr Operator that is running, unless you merely upgraded your existing deployment to `v0.3.0`.
+1. [Remove any finalizers](#remove-solr-resource-finalizers) that the Solr Resources may contain, in all namespaces that you run Solr resources in.
+1. [Remove the `solr.bloomberg.com` CRDs](#remove-bloomberg-solr-crds), as they are no longer needed when running the `v0.3.0` version of the Solr Operator.
+
+## If you manually manage your cluster
+
+If you manually manage your cluster, then the instructions below will allow you to upgrade in-place.
+
+1. Make sure you have the latest Apache Solr Operator helm charts (If you use helm to deploy the Solr Operator)
+   ```bash
+    helm repo add apache-solr https://solr.apache.org/charts
+    helm repo update
+    ```
+1. Upgrade to `v0.2.8`, if you are running a version lower.
+   - If your Solr Operator deployment is managed with a Helm chart, merely upgrade your helm chart to version `0.2.8`
 1. Install the v0.2.8 Solr Operator CRDs
-2. Upgrade the current Solr Operator to v0.2.8
-3. Install the Apache Solr Operator
-    helm install apache apache-solr/solr-operator --version v0.3.0
-4. fetch all BB resources, and upgrade them to Apache Resources
-    - Should we make a script?
-    - Definitely need to test this out
-    
+   ```bash
+    kubectl replace -f "https://solr.apache.org/operator/downloads/crds/v0.2.8/all.yaml"
+    ```
+   _The Upgrade Notes page says to always upgrade CRDs before upgrading the operator, however for this single upgrade case this order is safer._
+1. _If you are using the ZK Operator_  
+   [Remove the outdated Zookeeper Operator deployment and other resources](#removing-the-old-zookeeper-operator-resources).
+1. Install the Apache Solr CRDs
+   ```bash
+    kubectl create -f "https://solr.apache.org/operator/downloads/crds/v0.3.0/all.yaml"
+    ```
+   _If you are using the ZK Operator_
+   ```bash
+    kubectl create -f "https://solr.apache.org/operator/downloads/crds/v0.3.0/all-with-dependencies.yaml" || \
+      kubectl replace -f "https://solr.apache.org/operator/downloads/crds/v0.3.0/all-with-dependencies.yaml"
+    ```
+1. Install the Apache Solr Operator
+   ```bash
+    helm install apache apache-solr/solr-operator --version 0.3.0
+    ```
+1. Convert `solr.bloomberg.com` resources into `solr.apache.org` resources:
+   ```bash
+   # First make sure that "yq" is installed
+   kubectl get solrclouds.solr.bloomberg.com --all-namespaces -o yaml | \
+      sed "s#solr.bloomberg.com#solr.apache.org#g" | \
+      yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].spec.solrPodPolicy, .items.[].spec.zookeeperRef.provided.image.tag)' - \
+      | kubectl apply -f -
+   kubectl get solrprometheusexporters.solr.bloomberg.com --all-namespaces -o yaml | \
+      sed "s#solr.bloomberg.com#solr.apache.org#g" | \
+      yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].spec.podPolicy, .items.[].status)' - \
+      | kubectl apply -f -
+   kubectl get solrbackups.solr.bloomberg.com --all-namespaces -o yaml | \
+      sed "s#solr.bloomberg.com#solr.apache.org#g" | \
+      yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].status)' - \
+      | kubectl apply -f -
+   ```
+1. Delete the `v0.2.8` Solr Operator deployment:
+   ```bash
+   # If solr-operator is the name of your v0.2.8 Solr Operator deployment
+   helm delete solr-operator 
+   ```
+1. [Remove any finalizers](#remove-solr-resource-finalizers) that the Solr Resources may contain, in all namespaces that you run Solr resources in.
+1. [Remove the `solr.bloomberg.com` CRDs](#remove-bloomberg-solr-crds), as they are no longer needed when running the `v0.3.0` version of the Solr Operator.
+1. Test to make sure that your Solr resources exist as apache resources now and your `StatefulSets`/`Deployments` are still running correctly.
+
+## Other Considerations
+
+### Zookeeper Operator Upgrade
+
+The [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) version that the Solr Operator requires has changed between `v0.2.6` and `v0.3.0`.
+Therefore, the Zookeeper Operator needs to be upgraded to `v0.2.9` when the Solr Operator is upgraded to `v0.3.0`.
+
+#### Removing the old Zookeeper Operator resources
+If you use the Solr Operator [Helm chart](https://artifacthub.io/packages/helm/apache-solr/solr-operator), then the correct version of the Zookeeper Operator will be deployed when upgrading.
+However, you will need to pre-emptively delete some Kubernetes resources so that they can be managed by Helm.
+
+_Only use the below commands if you installed the Zookeeper Operator using the URL provided in the Solr Operator repository_
+
+```bash
+kubectl delete deployment zk-operator
+kubectl delete clusterrolebinding zookeeper-operator-cluster-role-binding
+kubectl delete clusterrole zookeeper-operator
+kubectl delete serviceaccount zookeeper-operator
+```
+
+You will then be able to install the Solr Operator & dependency CRDs, and the Solr Operator Helm Chart.
 
 
-## Need to account for
-- Upgrade of Zookeeper Operator dependency
-- Location of helm chart
+### Remove Solr Resource Finalizers
+
+It is necessary to remove any finalizers that the old `solr.bloomberg.com` resources may have, otherwise they will not be able to be deleted.
+You should do this for all namespaces that you are running solr resources in.
+
+**Only run these after stopping any `v0.2.x` Solr Operator that may be running in the Kubernetes cluster.**
+
+```bash
+kubectl get solrcollections.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrcollections.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
+kubectl get solrcollectionaliases.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrcollectionaliases.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
+kubectl get solrclouds.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrclouds.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
+```
+
+### Remove Bloomberg Solr CRDs
+
+After you have [removed all finalizers on Solr resources](#remove-solr-resource-finalizers), you can remove all `solr.bloomberg.com` CRDs.
+
+If you don't want to disrupt any Solr service that is running, make sure that all Solr resources have been upgraded from `solr.bloomberg.com` CRDs to `solr.apache.org` CRDs.
+This command will delete all `solr.bloomberg.com` resources, which means that only resources that exist as `solr.apache.org` will continue to run afterwards.
+
+```bash
+kubectl delete crd solrclouds.solr.bloomberg.com solrprometheusexporters.solr.bloomberg.com solrbackups.solr.bloomberg.com solrcollections.solr.bloomberg.com solrcollectionaliases.solr.bloomberg.com
+```

--- a/docs/upgrading-to-apache.md
+++ b/docs/upgrading-to-apache.md
@@ -1,0 +1,15 @@
+# Upgrading the Solr Operator from Bloomberg to Apache
+
+1. Install the v0.2.8 Solr Operator CRDs
+2. Upgrade the current Solr Operator to v0.2.8
+3. Install the Apache Solr Operator
+    helm install apache apache-solr/solr-operator --version v0.3.0
+4. fetch all BB resources, and upgrade them to Apache Resources
+    - Should we make a script?
+    - Definitely need to test this out
+    
+
+
+## Need to account for
+- Upgrade of Zookeeper Operator dependency
+- Location of helm chart

--- a/docs/upgrading-to-apache.md
+++ b/docs/upgrading-to-apache.md
@@ -96,7 +96,9 @@ Therefore, the Zookeeper Operator needs to be upgraded to `v0.2.9` when the Solr
 If you use the Solr Operator [Helm chart](https://artifacthub.io/packages/helm/apache-solr/solr-operator), then the correct version of the Zookeeper Operator will be deployed when upgrading.
 However, you will need to pre-emptively delete some Kubernetes resources so that they can be managed by Helm.
 
-_Only use the below commands if you installed the Zookeeper Operator using the URL provided in the Solr Operator repository_
+_Only use the below `kubectl` commands if you installed the Zookeeper Operator using the URL provided in the Solr Operator repository._  
+If you already have a `v0.2.9` Zookeeper Operator running, ignore this and pass the following options when installing the Solr Operator:
+`--set zookeeper-operator.install=false --set zookeeper-operator.use=true`
 
 ```bash
 kubectl delete deployment zk-operator

--- a/hack/headers/zookeeper-operator-header.yaml.txt
+++ b/hack/headers/zookeeper-operator-header.yaml.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Find source at: https://github.com/pravega/zookeeper-operator

--- a/hack/release/setup_release.sh
+++ b/hack/release/setup_release.sh
@@ -29,7 +29,6 @@ for filename in config/crd/bases/*.yaml; do
 done
 
 # Fetch the correct dependency Zookeeper CRD, package with other CRDS
- > release-artifacts/crds/all-with-dependencies.yaml
 {
   cat hack/headers/zookeeper-operator-header.yaml.txt;
   printf "\n\n---\n"

--- a/hack/release/setup_release.sh
+++ b/hack/release/setup_release.sh
@@ -8,9 +8,41 @@ set -u
 
 echo "Setting up Release ${VERSION}, making last commit."
 
-# Package and Index the helm charts, create release artifacts to upload in GithubRelease
-cp config/crd/bases/* release-artifacts/.
+mkdir -p release-artifacts/crds
 
-git add helm config docs
+# Create Release CRD files
+{
+  cat hack/headers/header.yaml.txt
+  printf "\n"
+} > release-artifacts/crds/all.yaml
+for filename in config/crd/bases/*.yaml; do
+    output_file=${filename#"config/crd/bases/solr.apache.org_"}
+    # Create individual file with Apache Header
+    {
+      cat hack/headers/header.yaml.txt;
+      printf "\n"
+      cat "${filename}";
+    } > "release-artifacts/crds/${output_file}"
 
-git commit -asm "Cutting release version ${VERSION} of the Solr Operator"
+    # Add to aggregate file
+    cat "${filename}" >> release-artifacts/crds/all.yaml
+done
+
+# Fetch the correct dependency Zookeeper CRD, package with other CRDS
+ > release-artifacts/crds/all-with-dependencies.yaml
+{
+  cat hack/headers/zookeeper-operator-header.yaml.txt;
+  printf "\n\n---\n"
+  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/v0.2.9/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml"
+} > release-artifacts/crds/zookeeperclusters.yaml
+
+# Package all Solr and Dependency CRDs
+{
+  cat release-artifacts/crds/all.yaml
+  printf "\n"
+  cat release-artifacts/crds/zookeeperclusters.yaml
+} > release-artifacts/crds/all-with-dependencies.yaml
+
+#git add helm config docs
+
+#git commit -asm "Cutting release version ${VERSION} of the Solr Operator"

--- a/hack/test-upgrade.sh
+++ b/hack/test-upgrade.sh
@@ -136,24 +136,15 @@ helm install apache helm/solr-operator --set image.tag=latest --set image.pullPo
 kubectl get solrclouds.solr.bloomberg.com --all-namespaces -o yaml | \
   sed "s#solr.bloomberg.com#solr.apache.org#g" | \
   yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].spec.solrPodPolicy, .items.[].spec.zookeeperRef.provided.image.tag)' - \
-  > apache_solrclouds.yaml
+  | kubectl apply -f -
 kubectl get solrprometheusexporters.solr.bloomberg.com --all-namespaces -o yaml | \
   sed "s#solr.bloomberg.com#solr.apache.org#g" | \
   yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].spec.podPolicy, .items.[].status)' - \
-  > apache_solrprometheusexporters.yaml
+  | kubectl apply -f -
 kubectl get solrbackups.solr.bloomberg.com --all-namespaces -o yaml | \
   sed "s#solr.bloomberg.com#solr.apache.org#g" | \
   yq eval 'del(.items.[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration", .items.[].metadata.managedFields, .items.[].metadata.resourceVersion, .items.[].metadata.creationTimestamp, .items.[].metadata.generation, .items.[].metadata.selfLink, .items.[].metadata.uid, .items.[].status)' - \
-  > apache_solrbackups.yaml
-
-# Make sure they look correct
-cat apache_solrclouds.yaml
-cat apache_solrprometheusexporters.yaml
-cat apache_solrbackups.yaml
-
-kubectl apply -f apache_solrclouds.yaml
-kubectl apply -f apache_solrprometheusexporters.yaml
-kubectl apply -f apache_solrbackups.yaml
+  | kubectl apply -f -
 
 
 ####
@@ -163,6 +154,7 @@ kubectl apply -f apache_solrbackups.yaml
 helm delete solr-operator
 
 # Remove finalizers for Collections and CollectionAliases
+kubectl get solrclouds.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrclouds.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
 kubectl get solrcollections.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrcollections.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
 kubectl get solrcollectionaliases.solr.bloomberg.com -o name | sed -e 's/.*\///g' | xargs -I {} kubectl patch solrcollectionaliases.solr.bloomberg.com {} --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers/0"}]'
 

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -38,6 +38,11 @@ zookeeper-operator:
   # If "zookeeper-operator.install" = true, then this setting is ignored.
   use: false
 
+  # By default we do not install the CRDs.
+  # Otherwise the ZookeeperCluster CRD will be deleted when deleting the Solr Operator helm chart release.
+  crd:
+    create: false
+
 # DEPRECATED: Please use "zookeeper-operator.use" instead.
 useZkOperator: "false"
 


### PR DESCRIPTION
Resolves #222 

This includes a test that installs v0.2.6, upgrades to v0.2.8 and then upgrades to v0.3.0.

The documentation gives two options, upgrading in an environment managed manually, and an environment managed via a system like Ansible.