### PR TITLE
Add more pod options in the Solr Operator helm chart.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 release-artifacts
+.DS_Store
 
 # Test binary, build with `go test -c`
 *.test

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -168,14 +168,19 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | fullnameOverride | string | `""` | A custom name for the Solr Operator Deployment |
 | nameOverride | string | `""` |  |
-| replicaCount | int | `1` | The number of Solr Operator pods to run |
-| resources.limits.cpu | string | `"400m"` |  |
-| resources.limits.memory | string | `"500Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"100Mi"` |  |
-| rbac.create | boolean | true | Create the necessary RBAC rules, whether cluster-wide or namespaced, for the Solr Operator. |
-| serviceAccount.create | boolean | true | Create a serviceAccount to be used for this operator. This serviceAccount will be given the permissions specified in the operator's RBAC rules. |
-| serviceAccount.name | string | "" | If `serviceAccount.create` is set to `false`, the name of an existing serviceAccount in the target namespace **must** be provided to run the Solr Operator with. This serviceAccount with be given the operator's RBAC rules. | 
+| replicaCount | int | `1` | The number of Solr Operator pods to run
+| rbac.create | boolean | `true` | Create the necessary RBAC rules, whether cluster-wide or namespaced, for the Solr Operator. |
+| serviceAccount.create | boolean | `true` | Create a serviceAccount to be used for this operator. This serviceAccount will be given the permissions specified in the operator's RBAC rules. |
+| serviceAccount.name | string | `""` | If `serviceAccount.create` is set to `false`, the name of an existing serviceAccount in the target namespace **must** be provided to run the Solr Operator with. This serviceAccount with be given the operator's RBAC rules. | |
+| resources.limits | map[string]string |  | Provide Resource limits for the Solr Operator container |
+| resources.limits | map[string]string |  | Provide Resource requests for the Solr Operator container |
+| labels | map[string]string |  | Custom labels to add to the Solr Operator pod |
+| annotations | map[string]string |  | Custom annotations to add to the Solr Operator pod |
+| nodeSelector | map[string]string |  | Add a node selector for the Solr Operator pod, to specify where it can be scheduled |
+| affinity | object |  | Add Kubernetes affinity information for the Solr Operator pod |
+| tolerations | []object |  | Specify a list of Kubernetes tolerations for the Solr Operator pod |
+| priorityClassName | string | `""` | Give a priorityClassName for the Solr Operator pod |
+| sidecarContainers | []object |  | An optional list of additional containers to run along side the Solr Operator in its pod |
 
 ### Configuring the Zookeeper Operator
 

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -19,22 +19,28 @@ metadata:
   name: {{ include "solr-operator.fullname" . }}
   labels:
     control-plane: solr-operator
-    controller-tools.k8s.io: "1.0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       control-plane: solr-operator
-      controller-tools.k8s.io: "1.0"
   template:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        {{- if .Values.annotations }}
+        {{ toYaml .Values.annotations | nindent 8 }}
+        {{- end }}
       labels:
         control-plane: solr-operator
-        controller-tools.k8s.io: "1.0"
+        {{- if .Values.labels }}
+        {{ toYaml .Values.labels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "solr-operator.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" 
@@ -61,4 +67,19 @@ spec:
           {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+      {{- if .Values.sidecarContainers }}
+      {{ toYaml .Values.sidecarContainers | nindent 6 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -21,7 +21,7 @@ replicaCount: 1
 
 image:
   repository: apache/solr-operator
-  tag: v0.3.0
+  tag: v0.3.0-prerelease
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -62,12 +62,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-resources:
-  limits:
-    cpu: 400m
-    memory: 500Mi
-  requests:
-    cpu: 100m
-    memory: 100Mi
-
+# Various Pod Options to customize the runtime of the operator
+resources: {}
 envVars: []
+labels: {}
+annotations: {}
+nodeSelector: {}
+affinity: {}
+tolerations: []
+priorityClassName: ""
+sidecarContainers: []


### PR DESCRIPTION
This adds the following options in the Solr Operator helm chart:
- labels
- annotations
- nodeSelector
- affinity
- tolerations
- priorityClassName
- sidecarContainers

The Solr Operator container resources also no longer have a default value.