### PR TITLE
Add support for HPA

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -729,6 +729,7 @@ type SolrNodeStatus struct {
 // +kubebuilder:printcolumn:name="Nodes",type="integer",JSONPath=".status.replicas",description="Number of solr nodes running"
 // +kubebuilder:printcolumn:name="ReadyNodes",type="integer",JSONPath=".status.readyReplicas",description="Number of solr nodes connected to the cloud"
 // +kubebuilder:printcolumn:name="UpToDateNodes",type="integer",JSONPath=".status.upToDateNodes",description="Number of solr nodes running the latest SolrCloud pod spec"
+// +kubebuilder:printcolumn:name="Selector",type="string",JSONPath=".status.selector",description="Solr pods selector used by HPA"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type SolrCloud struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -655,8 +655,8 @@ type SolrCloudStatus struct {
 	// Replicas is the number of number of desired replicas in the cluster
 	Replicas int32 `json:"replicas"`
 
-	// Selector field in the CR status is required by the HPA
-	PodSelector string `json:"selector"`
+	// PodSelector for SolrCloud pods, required by the HPA
+	PodSelector string `json:"podSelector"`
 
 	// ReadyReplicas is the number of number of ready replicas in the cluster
 	ReadyReplicas int32 `json:"readyReplicas"`
@@ -722,7 +722,7 @@ type SolrNodeStatus struct {
 // +kubebuilder:resource:shortName=solr
 // +kubebuilder:categories=all
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyReplicas,selectorpath=.status.selector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyReplicas,selectorpath=.status.podSelector
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Solr Version of the cloud"
 // +kubebuilder:printcolumn:name="TargetVersion",type="string",JSONPath=".status.targetVersion",description="Target Solr Version of the cloud"
 // +kubebuilder:printcolumn:name="DesiredNodes",type="integer",JSONPath=".spec.replicas",description="Number of solr nodes configured to run in the cloud"

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -655,8 +655,8 @@ type SolrCloudStatus struct {
 	// Replicas is the number of number of desired replicas in the cluster
 	Replicas int32 `json:"replicas"`
 
-	// Selector is required by the HPA
-	Selector string `json:"selector"`
+	// Selector field in the CR status is required by the HPA
+	PodSelector string `json:"selector"`
 
 	// ReadyReplicas is the number of number of ready replicas in the cluster
 	ReadyReplicas int32 `json:"readyReplicas"`
@@ -729,7 +729,6 @@ type SolrNodeStatus struct {
 // +kubebuilder:printcolumn:name="Nodes",type="integer",JSONPath=".status.replicas",description="Number of solr nodes running"
 // +kubebuilder:printcolumn:name="ReadyNodes",type="integer",JSONPath=".status.readyReplicas",description="Number of solr nodes connected to the cloud"
 // +kubebuilder:printcolumn:name="UpToDateNodes",type="integer",JSONPath=".status.upToDateNodes",description="Number of solr nodes running the latest SolrCloud pod spec"
-// +kubebuilder:printcolumn:name="Selector",type="string",JSONPath=".status.selector",description="Solr pods selector used by HPA"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type SolrCloud struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -19,9 +19,10 @@ package v1beta1
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	zk "github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -654,6 +655,9 @@ type SolrCloudStatus struct {
 	// Replicas is the number of number of desired replicas in the cluster
 	Replicas int32 `json:"replicas"`
 
+	// Selector is required by the HPA
+	Selector string `json:"selector"`
+
 	// ReadyReplicas is the number of number of ready replicas in the cluster
 	ReadyReplicas int32 `json:"readyReplicas"`
 
@@ -718,7 +722,7 @@ type SolrNodeStatus struct {
 // +kubebuilder:resource:shortName=solr
 // +kubebuilder:categories=all
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyReplicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyReplicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Solr Version of the cloud"
 // +kubebuilder:printcolumn:name="TargetVersion",type="string",JSONPath=".status.targetVersion",description="Target Solr Version of the cloud"
 // +kubebuilder:printcolumn:name="DesiredNodes",type="integer",JSONPath=".spec.replicas",description="Number of solr nodes configured to run in the cloud"

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -5192,6 +5192,9 @@ spec:
               internalCommonAddress:
                 description: InternalCommonAddress is the internal common http address for all solr nodes
                 type: string
+              podSelector:
+                description: PodSelector for SolrCloud pods, required by the HPA
+                type: string
               readyReplicas:
                 description: ReadyReplicas is the number of number of ready replicas in the cluster
                 format: int32
@@ -5200,9 +5203,6 @@ spec:
                 description: Replicas is the number of number of desired replicas in the cluster
                 format: int32
                 type: integer
-              selector:
-                description: Selector field in the CR status is required by the HPA
-                type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.
                 items:
@@ -5298,9 +5298,9 @@ spec:
             required:
             - backupRestoreReady
             - internalCommonAddress
+            - podSelector
             - readyReplicas
             - replicas
-            - selector
             - solrNodes
             - upToDateNodes
             - version
@@ -5311,7 +5311,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.selector
+        labelSelectorPath: .status.podSelector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.readyReplicas
       status: {}

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -5200,6 +5200,9 @@ spec:
                 description: Replicas is the number of number of desired replicas in the cluster
                 format: int32
                 type: integer
+              selector:
+                description: Selector is required by the HPA
+                type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.
                 items:
@@ -5297,6 +5300,7 @@ spec:
             - internalCommonAddress
             - readyReplicas
             - replicas
+            - selector
             - solrNodes
             - upToDateNodes
             - version
@@ -5307,6 +5311,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.readyReplicas
       status: {}

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -43,6 +43,10 @@ spec:
       jsonPath: .status.upToDateNodes
       name: UpToDateNodes
       type: integer
+    - description: Solr pods selector used by HPA
+      jsonPath: .status.selector
+      name: Selector
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -43,10 +43,6 @@ spec:
       jsonPath: .status.upToDateNodes
       name: UpToDateNodes
       type: integer
-    - description: Solr pods selector used by HPA
-      jsonPath: .status.selector
-      name: Selector
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -5205,7 +5201,7 @@ spec:
                 format: int32
                 type: integer
               selector:
-                description: Selector is required by the HPA
+                description: Selector field in the CR status is required by the HPA
                 type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -21,6 +21,11 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
 	solr "github.com/apache/solr-operator/api/v1beta1"
 	"github.com/apache/solr-operator/controllers/util"
 	"github.com/go-logr/logr"
@@ -34,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,9 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sort"
-	"strings"
-	"time"
 )
 
 // SolrCloudReconciler reconciles a SolrCloud object
@@ -575,6 +576,7 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 	updateRevision := statefulSetStatus.UpdateRevision
 
 	newStatus.Replicas = statefulSetStatus.Replicas
+	newStatus.Selector = "solr-cloud=" + selectorLabels["solr-cloud"]
 	newStatus.UpToDateNodes = int32(0)
 	newStatus.ReadyReplicas = int32(0)
 	for idx, p := range foundPods.Items {

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -466,7 +466,7 @@ func (r *SolrCloudReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	var outOfDatePods, outOfDatePodsNotStarted []corev1.Pod
 	var availableUpdatedPodCount int
-	outOfDatePods, outOfDatePodsNotStarted, availableUpdatedPodCount, err = reconcileCloudStatus(r, instance, &newStatus, statefulSetStatus)
+	outOfDatePods, outOfDatePodsNotStarted, availableUpdatedPodCount, err = reconcileCloudStatus(r, instance, logger, &newStatus, statefulSetStatus)
 	if err != nil {
 		return requeueOrNot, err
 	}
@@ -552,7 +552,7 @@ func (r *SolrCloudReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return requeueOrNot, nil
 }
 
-func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, newStatus *solr.SolrCloudStatus, statefulSetStatus appsv1.StatefulSetStatus) (outOfDatePods []corev1.Pod, outOfDatePodsNotStarted []corev1.Pod, availableUpdatedPodCount int, err error) {
+func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, logger logr.Logger, newStatus *solr.SolrCloudStatus, statefulSetStatus appsv1.StatefulSetStatus) (outOfDatePods []corev1.Pod, outOfDatePodsNotStarted []corev1.Pod, availableUpdatedPodCount int, err error) {
 	foundPods := &corev1.PodList{}
 	selectorLabels := solrCloud.SharedLabels()
 	selectorLabels["technology"] = solr.SolrTechnologyLabel
@@ -574,11 +574,16 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 	backupRestoreReadyPods := 0
 
 	updateRevision := statefulSetStatus.UpdateRevision
-
-	newStatus.Replicas = statefulSetStatus.Replicas
-	newStatus.Selector = "solr-cloud=" + selectorLabels["solr-cloud"]
 	newStatus.UpToDateNodes = int32(0)
 	newStatus.ReadyReplicas = int32(0)
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: selectorLabels,
+	})
+	if err != nil {
+		logger.Error(err, "Error getting SolrCloud PodSelector labels")
+		return outOfDatePods, outOfDatePodsNotStarted, availableUpdatedPodCount, err
+	}
+	newStatus.PodSelector = selector.String()
 	for idx, p := range foundPods.Items {
 		nodeNames[idx] = p.Name
 		nodeStatus := solr.SolrNodeStatus{}

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -169,6 +169,24 @@ kubectl get solrclouds -w
 # Hit Control-C when done
 ```
 
+The SolrCloud CRD is setup so that it is able to run with the HPA.
+Merely use the following when creating an HPA object:
+```yaml
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-solr
+spec:
+  maxReplicas: 6
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: solr.apache.com/v1beta1
+    kind: SolrCloud
+    name: example
+  metrics:
+    ....
+ ```
+
 ## Upgrade to newer version
 
 So we wish to upgrade to a newer Solr version:

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -9,6 +9,7 @@ This tutorial shows how to setup Solr under Kubernetes on your local mac. The pl
  4. [Start your Solr cluster](#start-an-example-solr-cloud-cluster)
  5. [Create a collection and index some documents](#create-a-collection-and-index-some-documents)
  6. [Scale from 3 to 5 nodes](#scale-from-3-to-5-nodes)
+    1. [Using the Horizontal Pod Autoscaler](#horizontal-pod-autoscaler-hpa)
  7. [Upgrade to newer Solr version](#upgrade-to-newer-version)
  8. [Install Kubernetes Dashboard (optional)](#install-kubernetes-dashboard-optional)
  9. [Delete the solrCloud cluster named 'example'](#delete-the-solrcloud-cluster-named-example)
@@ -169,6 +170,8 @@ kubectl get solrclouds -w
 # Hit Control-C when done
 ```
 
+### Horizontal Pod Autoscaler (HPA)
+
 The SolrCloud CRD is setup so that it is able to run with the HPA.
 Merely use the following when creating an HPA object:
 ```yaml
@@ -186,6 +189,9 @@ spec:
   metrics:
     ....
  ```
+
+Make sure that you are not overwriting the `SolrCloud.Spec.replicas` field when doing `kubectl apply`,
+otherwise you will be undoing the autoscaler's work.
 
 ## Upgrade to newer version
 

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -1184,10 +1184,6 @@ spec:
       jsonPath: .status.upToDateNodes
       name: UpToDateNodes
       type: integer
-    - description: Solr pods selector used by HPA
-      jsonPath: .status.selector
-      name: Selector
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -6346,7 +6342,7 @@ spec:
                 format: int32
                 type: integer
               selector:
-                description: Selector is required by the HPA
+                description: Selector field in the CR status is required by the HPA
                 type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -6341,6 +6341,9 @@ spec:
                 description: Replicas is the number of number of desired replicas in the cluster
                 format: int32
                 type: integer
+              selector:
+                description: Selector is required by the HPA
+                type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.
                 items:
@@ -6438,6 +6441,7 @@ spec:
             - internalCommonAddress
             - readyReplicas
             - replicas
+            - selector
             - solrNodes
             - upToDateNodes
             - version
@@ -6448,6 +6452,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.readyReplicas
       status: {}

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -1184,6 +1184,10 @@ spec:
       jsonPath: .status.upToDateNodes
       name: UpToDateNodes
       type: integer
+    - description: Solr pods selector used by HPA
+      jsonPath: .status.selector
+      name: Selector
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -6333,6 +6333,9 @@ spec:
               internalCommonAddress:
                 description: InternalCommonAddress is the internal common http address for all solr nodes
                 type: string
+              podSelector:
+                description: PodSelector for SolrCloud pods, required by the HPA
+                type: string
               readyReplicas:
                 description: ReadyReplicas is the number of number of ready replicas in the cluster
                 format: int32
@@ -6341,9 +6344,6 @@ spec:
                 description: Replicas is the number of number of desired replicas in the cluster
                 format: int32
                 type: integer
-              selector:
-                description: Selector field in the CR status is required by the HPA
-                type: string
               solrNodes:
                 description: SolrNodes contain the statuses of each solr node running in this solr cloud.
                 items:
@@ -6439,9 +6439,9 @@ spec:
             required:
             - backupRestoreReady
             - internalCommonAddress
+            - podSelector
             - readyReplicas
             - replicas
-            - selector
             - solrNodes
             - upToDateNodes
             - version
@@ -6452,7 +6452,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.selector
+        labelSelectorPath: .status.podSelector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.readyReplicas
       status: {}


### PR DESCRIPTION
This fixes #251 

A user should be able to scale the SolrCloud CR using HPA:

```yaml
# hpa reference
...
spec:
  maxReplicas: 6
  minReplicas: 3
  scaleTargetRef:
    apiVersion: solr.apache.com/v1beta1
    kind: SolrCloud
    name: my-solr-cluster
  metrics:
   ....
```

Field `spec.replicas` from the SolrCloud CR should be left unset (it's already optional) if HPA is used, just like for deployment replicas field and HPA. 

The HPA has to be defined separately and it's not part of the Operator, thus, the user is responsible for choosing the metrics and the logic of HPA.