### PR TITLE
Ability to customize serviceAccountName for SolrCloud and SolrPrometheusExporter

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -129,6 +129,10 @@ type PodOptions struct {
 	// +kubebuilder:validation:Minimum=10
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// Optional Service Account to run the pod under.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // ServiceOptions defines custom options for services

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -688,6 +688,10 @@ type ZookeeperPodPolicy struct {
 	// This field cannot be updated once the cluster is created.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// Optional Service Account to run the zookeeper pods under.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // SolrCloudStatus defines the observed state of SolrCloud

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -1620,6 +1620,9 @@ spec:
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      serviceAccountName:
+                        description: Optional Service Account to run the pod under.
+                        type: string
                       sidecarContainers:
                         description: Sidecar containers to run in the pod. These are in addition to the Solr Container
                         items:

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -5329,6 +5329,9 @@ spec:
                                 description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
+                          serviceAccountName:
+                            description: Optional Service Account to run the zookeeper pods under.
+                            type: string
                           tolerations:
                             description: Tolerations to be added on pods.
                             items:

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -1549,6 +1549,9 @@ spec:
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      serviceAccountName:
+                        description: Optional Service Account to run the pod under.
+                        type: string
                       sidecarContainers:
                         description: Sidecar containers to run in the pod. These are in addition to the Solr Container
                         items:

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -745,4 +745,5 @@ var (
 			ImagePullPolicy:          "Always",
 		},
 	}
+	testServiceAccountName = "test-service-account"
 )

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -208,7 +208,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 					PriorityClassName:             testPriorityClass,
 					ImagePullSecrets:              testAdditionalImagePullSecrets,
 					TerminationGracePeriodSeconds: &testTerminationGracePeriodSeconds,
-					ServiceAccountName: 		   testServiceAccountName,
+					ServiceAccountName:            testServiceAccountName,
 				},
 				StatefulSetOptions: &solr.StatefulSetOptions{
 					Annotations:         testSSAnnotations,

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -208,6 +208,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 					PriorityClassName:             testPriorityClass,
 					ImagePullSecrets:              testAdditionalImagePullSecrets,
 					TerminationGracePeriodSeconds: &testTerminationGracePeriodSeconds,
+					ServiceAccountName: 		   testServiceAccountName,
 				},
 				StatefulSetOptions: &solr.StatefulSetOptions{
 					Annotations:         testSSAnnotations,
@@ -299,6 +300,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 	assert.EqualValues(t, testPriorityClass, statefulSet.Spec.Template.Spec.PriorityClassName, "Incorrect Priority class name for Pod Spec")
 	assert.ElementsMatch(t, append(testAdditionalImagePullSecrets, corev1.LocalObjectReference{Name: testImagePullSecretName}), statefulSet.Spec.Template.Spec.ImagePullSecrets, "Incorrect imagePullSecrets")
 	assert.EqualValues(t, &testTerminationGracePeriodSeconds, statefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds, "Incorrect terminationGracePeriodSeconds")
+	assert.EqualValues(t, testServiceAccountName, statefulSet.Spec.Template.Spec.ServiceAccountName, "Incorrect serviceAccountName")
 
 	// Check the update strategy
 	assert.EqualValues(t, appsv1.RollingUpdateStatefulSetStrategyType, statefulSet.Spec.UpdateStrategy.Type, "Incorrect statefulset update strategy")
@@ -394,6 +396,7 @@ func TestCloudWithProvidedZookeeperReconcile(t *testing.T) {
 	testPodEnvVariables(t, expectedEnvVars, statefulSet.Spec.Template.Spec.Containers[0].Env)
 	testMapsEqual(t, "statefulSet annotations", expectedStatefulSetAnnotations, statefulSet.Annotations)
 	assert.EqualValues(t, []string{"sh", "-c", "solr zk ls ${ZK_CHROOT} -z ${ZK_SERVER} || solr zk mkroot ${ZK_CHROOT} -z ${ZK_SERVER}"}, statefulSet.Spec.Template.Spec.Containers[0].Lifecycle.PostStart.Exec.Command, "Incorrect post-start command")
+	assert.Empty(t, statefulSet.Spec.Template.Spec.ServiceAccountName, "No custom serviceAccountName specified, so the field should be empty.")
 
 	// Check the update strategy
 	assert.EqualValues(t, appsv1.OnDeleteStatefulSetStrategyType, statefulSet.Spec.UpdateStrategy.Type, "Incorrect statefulset update strategy")

--- a/controllers/solrprometheusexporter_controller_test.go
+++ b/controllers/solrprometheusexporter_controller_test.go
@@ -262,12 +262,12 @@ func TestMetricsReconcileWithGivenZkAcls(t *testing.T) {
 			},
 			CustomKubeOptions: solr.CustomExporterKubeOptions{
 				PodOptions: &solr.PodOptions{
-					EnvVariables: extraVars,
-					Annotations:  testPodAnnotations,
-					Labels:       testPodLabels,
-					Volumes:      extraVolumes,
-					Tolerations:  testTolerationsPromExporter,
-					NodeSelector: testNodeSelectors,
+					EnvVariables:       extraVars,
+					Annotations:        testPodAnnotations,
+					Labels:             testPodLabels,
+					Volumes:            extraVolumes,
+					Tolerations:        testTolerationsPromExporter,
+					NodeSelector:       testNodeSelectors,
 					ServiceAccountName: testServiceAccountName,
 				},
 				DeploymentOptions: &solr.DeploymentOptions{

--- a/controllers/solrprometheusexporter_controller_test.go
+++ b/controllers/solrprometheusexporter_controller_test.go
@@ -268,6 +268,7 @@ func TestMetricsReconcileWithGivenZkAcls(t *testing.T) {
 					Volumes:      extraVolumes,
 					Tolerations:  testTolerationsPromExporter,
 					NodeSelector: testNodeSelectors,
+					ServiceAccountName: testServiceAccountName,
 				},
 				DeploymentOptions: &solr.DeploymentOptions{
 					Annotations: testDeploymentAnnotations,
@@ -403,6 +404,7 @@ func TestMetricsReconcileWithGivenZkAcls(t *testing.T) {
 	assert.Equal(t, len(extraVolumes)+1, len(deployment.Spec.Template.Spec.Volumes), "Pod has wrong number of volumes")
 	assert.Equal(t, extraVolumes[0].Name, deployment.Spec.Template.Spec.Volumes[1].Name, "Additional Volume from podOptions not loaded into pod properly.")
 	assert.Equal(t, extraVolumes[0].Source, deployment.Spec.Template.Spec.Volumes[1].VolumeSource, "Additional Volume from podOptions not loaded into pod properly.")
+	assert.Equal(t, testServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName, "Incorrect serviceAccountName.")
 
 	expectedServiceLabels := util.MergeLabelsOrAnnotations(instance.SharedLabelsWith(instance.Labels), map[string]string{"service-type": "metrics"})
 	expectedServiceAnnotations := map[string]string{"prometheus.io/path": "/metrics", "prometheus.io/port": "80", "prometheus.io/scheme": "http", "prometheus.io/scrape": "true"}
@@ -570,6 +572,7 @@ func TestMetricsReconcileWithSolrZkAcls(t *testing.T) {
 	assert.Equal(t, zkAclEnvVars, foundEnv[0:5], "ZK ACL Env Vars are not correct")
 	assert.Equal(t, extraVars, foundEnv[5:len(foundEnv)-1], "Extra Env Vars are not the same as the ones provided in podOptions")
 	testMetricsPodEnvVariables(t, expectedEnvVars, foundEnv[len(foundEnv)-1:])
+	assert.Empty(t, deployment.Spec.Template.Spec.ServiceAccountName, "No custom serviceAccountName specified, so the field should be empty.")
 
 	expectedServiceLabels := util.MergeLabelsOrAnnotations(instance.SharedLabelsWith(instance.Labels), map[string]string{"service-type": "metrics"})
 	expectedServiceAnnotations := map[string]string{"prometheus.io/path": "/metrics", "prometheus.io/port": "80", "prometheus.io/scheme": "http", "prometheus.io/scrape": "true"}

--- a/controllers/util/common.go
+++ b/controllers/util/common.go
@@ -431,6 +431,12 @@ func CopyPodTemplates(from, to *corev1.PodTemplateSpec, basePath string, logger 
 		to.Spec.TerminationGracePeriodSeconds = from.Spec.TerminationGracePeriodSeconds
 	}
 
+	if !DeepEqualWithNils(to.Spec.ServiceAccountName, from.Spec.ServiceAccountName) {
+		requireUpdate = true
+		logger.Info("Update required because field changed", "field", basePath+"Spec.ServiceAccountName", "from", to.Spec.ServiceAccountName, "to", from.Spec.ServiceAccountName)
+		to.Spec.ServiceAccountName = from.Spec.ServiceAccountName
+	}
+
 	return requireUpdate
 }
 

--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -303,6 +303,10 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 	deployment.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 	if nil != customPodOptions {
+		if customPodOptions.ServiceAccountName != "" {
+			deployment.Spec.Template.Spec.ServiceAccountName = customPodOptions.ServiceAccountName
+		}
+
 		if customPodOptions.Affinity != nil {
 			deployment.Spec.Template.Spec.Affinity = customPodOptions.Affinity
 		}

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -552,6 +552,10 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 	stateful.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 	if nil != customPodOptions {
+		if customPodOptions.ServiceAccountName != "" {
+			stateful.Spec.Template.Spec.ServiceAccountName = customPodOptions.ServiceAccountName
+		}
+
 		if customPodOptions.Affinity != nil {
 			stateful.Spec.Template.Spec.Affinity = customPodOptions.Affinity
 		}

--- a/controllers/util/zk_util.go
+++ b/controllers/util/zk_util.go
@@ -209,7 +209,7 @@ func CopyZookeeperClusterFields(from, to *zk.ZookeeperCluster, logger logr.Logge
 	// The Zookeeper Operator defaults the serviceAccountName to "default", therefore only update if either of the following
 	//   - The new serviceAccountName is not empty
 	//   - The old serviceAccountName is not "default", so we know we want to switch to the default value.
-	if !DeepEqualWithNils(to.Spec.Pod.ServiceAccountName, from.Spec.Pod.ServiceAccountName) && (from.Spec.Pod.ServiceAccountName != "" || to.Spec.Pod.ServiceAccountName != "default"){
+	if !DeepEqualWithNils(to.Spec.Pod.ServiceAccountName, from.Spec.Pod.ServiceAccountName) && (from.Spec.Pod.ServiceAccountName != "" || to.Spec.Pod.ServiceAccountName != "default") {
 		logger.Info("Update required because field changed", "field", "Spec.Pod.ServiceAccountName", "from", to.Spec.Pod.ServiceAccountName, "to", from.Spec.Pod.ServiceAccountName)
 		requireUpdate = true
 		to.Spec.Pod.ServiceAccountName = from.Spec.Pod.ServiceAccountName

--- a/controllers/util/zk_util.go
+++ b/controllers/util/zk_util.go
@@ -93,6 +93,10 @@ func GenerateZookeeperCluster(solrCloud *solr.SolrCloud, zkSpec *solr.ZookeeperS
 		zkCluster.Spec.KubernetesClusterDomain = solrCloud.Spec.SolrAddressability.KubeDomain
 	}
 
+	if zkSpec.ZookeeperPod.ServiceAccountName != "" {
+		zkCluster.Spec.Pod.ServiceAccountName = zkSpec.ZookeeperPod.ServiceAccountName
+	}
+
 	return zkCluster
 }
 
@@ -201,6 +205,15 @@ func CopyZookeeperClusterFields(from, to *zk.ZookeeperCluster, logger logr.Logge
 		requireUpdate = true
 	}
 	to.Spec.Pod.Affinity = from.Spec.Pod.Affinity
+
+	// The Zookeeper Operator defaults the serviceAccountName to "default", therefore only update if either of the following
+	//   - The new serviceAccountName is not empty
+	//   - The old serviceAccountName is not "default", so we know we want to switch to the default value.
+	if !DeepEqualWithNils(to.Spec.Pod.ServiceAccountName, from.Spec.Pod.ServiceAccountName) && (from.Spec.Pod.ServiceAccountName != "" || to.Spec.Pod.ServiceAccountName != "default"){
+		logger.Info("Update required because field changed", "field", "Spec.Pod.ServiceAccountName", "from", to.Spec.Pod.ServiceAccountName, "to", from.Spec.Pod.ServiceAccountName)
+		requireUpdate = true
+		to.Spec.Pod.ServiceAccountName = from.Spec.Pod.ServiceAccountName
+	}
 
 	if !DeepEqualWithNils(to.Spec.KubernetesClusterDomain, from.Spec.KubernetesClusterDomain) && from.Spec.KubernetesClusterDomain != "" {
 		logger.Info("Update required because field changed", "field", "Spec.KubernetesClusterDomain", "from", to.Spec.KubernetesClusterDomain, "to", from.Spec.KubernetesClusterDomain)

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -61,6 +61,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/281
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/279
+    - kind: added
+      description: Customize serviceAccountName for SolrCloud and SolrPrometheusExporter
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/264
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/283
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -2747,6 +2747,9 @@ spec:
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      serviceAccountName:
+                        description: Optional Service Account to run the pod under.
+                        type: string
                       sidecarContainers:
                         description: Sidecar containers to run in the pod. These are in addition to the Solr Container
                         items:
@@ -8158,6 +8161,9 @@ spec:
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      serviceAccountName:
+                        description: Optional Service Account to run the pod under.
+                        type: string
                       sidecarContainers:
                         description: Sidecar containers to run in the pod. These are in addition to the Solr Container
                         items:

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -6456,6 +6456,9 @@ spec:
                                 description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
+                          serviceAccountName:
+                            description: Optional Service Account to run the zookeeper pods under.
+                            type: string
                           tolerations:
                             description: Tolerations to be added on pods.
                             items:

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -60,7 +60,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # Required if create is false.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
 
 # Various Pod Options to customize the runtime of the operator
 resources: {}

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -48,6 +48,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/112
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/276
+    - kind: added
+      description: Ability to create serviceAccount for SolrCloud deployment through Helm chart.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/264
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/283
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -211,7 +211,8 @@ Solr TLS is disabled by default. Provide any of the following to enable it.
 | podOptions.nodeSelector | map[string]string |  | Add a node selector for the Solr pod, to specify where it can be scheduled |
 | podOptions.affinity | object |  | Add Kubernetes affinity information for the Solr pod |
 | podOptions.tolerations | []object |  | Specify a list of Kubernetes tolerations for the Solr pod |
-| podOptions.priorityClassName | string | | Give a priorityClassName for the Solr pod |
+| podOptions.serviceAccountName | string |  | Optional serviceAccount to run the Solr pods under |
+| podOptions.priorityClassName | string | | Optional priorityClassName for the Solr pod |
 | podOptions.sidecarContainers | []object |  | An optional list of additional containers to run along side the Solr in its pod |
 | podOptions.initContainers | []object |  | An optional list of additional initContainers to run before the Solr container starts |
 | podOptions.envVars | []object |  | List of additional environment variables for the Solr container |

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -97,6 +97,8 @@ The command removes the SolrCloud resource, and then Kubernetes will garbage col
 | updateStrategy.managedUpdate.maxPodsUnavailable | int-or-string | `"25%"` | The number of Solr pods in a Solr Cloud that are allowed to be unavailable during the rolling restart. Either a static number, or a percentage representing the percentage of total pods requested for the statefulSet. |
 | updateStrategy.managedUpdate.maxShardReplicasUnavailable | int-or-string | `1` | The number of replicas for each shard allowed to be unavailable during the restart. Either a static number, or a percentage representing the percentage of the number of replicas for a shard. |
 | updateStrategy.restartSchedule | [string (CRON)](https://pkg.go.dev/github.com/robfig/cron/v3?utm_source=godoc#hdr-CRON_Expression_Format) | | A CRON schedule for automatically restarting the Solr Cloud. [Refer here](https://pkg.go.dev/github.com/robfig/cron/v3?utm_source=godoc#hdr-CRON_Expression_Format) for all possible CRON syntaxes accepted. |
+| serviceAccount.create | boolean | `false` | Create a serviceAccount to be used for all pods being deployed (Solr & ZK). If `serviceAccount.name` is not specified, the full name of the deployment will be used. |
+| serviceAccount.name | string |  | The optional default service account used for Solr and ZK unless overridden below. If `serviceAccount.create` is set to `false`, this serviceAccount must exist in the target namespace. |
 
 ### Data Storage Options
 
@@ -157,6 +159,7 @@ Currently the Zookeeper Operator does not support ACLs, so do not use the provid
 | zk.provided.image.imagePullSecret | string |  | PullSecret for the ZooKeeper image |
 | zk.provided.persistence.reclaimPolicy | string | `"Retain"` | Determines whether to delete or keep the PVCs when ZooKeeper is deleted or scaled down. Either `Retain` or `Delete`. |
 | zk.provided.persistence.spec | object | | A PVC Spec for the ZooKeeper PVC(s) |
+| zk.provided.zookeeperPodPolicy.serviceAccountName | string |  | Optional serviceAccount to run the ZK Pod under |
 | zk.provided.zookeeperPodPolicy.affinity | string |  | PullSecret for the ZooKeeper image |
 | zk.provided.zookeeperPodPolicy.resources.limits | map[string]string |  | Provide Resource limits for the ZooKeeper containers |
 | zk.provided.zookeeperPodPolicy.resources.requests | map[string]string |  | Provide Resource requests for the ZooKeeper containers |

--- a/helm/solr/templates/_custom_option_helpers.tpl
+++ b/helm/solr/templates/_custom_option_helpers.tpl
@@ -33,8 +33,8 @@ annotations:
 resources:
   {{- toYaml .Values.podOptions.resources | nindent 2 }}
 {{ end }}
-{{- if .Values.podOptions.serviceAccountName -}}
-serviceAccountName: {{ .Values.podOptions.serviceAccountName }}
+{{- if (include "solr.serviceAccountName.solr" .) -}}
+serviceAccountName: {{ include "solr.serviceAccountName.solr" . }}
 {{ end }}
 {{- if .Values.podOptions.priorityClassName -}}
 priorityClassName: {{ .Values.podOptions.priorityClassName }}

--- a/helm/solr/templates/_custom_option_helpers.tpl
+++ b/helm/solr/templates/_custom_option_helpers.tpl
@@ -33,6 +33,9 @@ annotations:
 resources:
   {{- toYaml .Values.podOptions.resources | nindent 2 }}
 {{ end }}
+{{- if .Values.podOptions.serviceAccountName -}}
+serviceAccountName: {{ .Values.podOptions.serviceAccountName }}
+{{ end }}
 {{- if .Values.podOptions.priorityClassName -}}
 priorityClassName: {{ .Values.podOptions.priorityClassName }}
 {{ end }}

--- a/helm/solr/templates/_helpers.tpl
+++ b/helm/solr/templates/_helpers.tpl
@@ -73,6 +73,31 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use globally
+*/}}
+{{- define "solr.serviceAccountName.global" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name | default (include "solr.fullname" .) }}
+{{- else -}}
+{{ .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for Solr
+*/}}
+{{- define "solr.serviceAccountName.solr" -}}
+{{ .Values.podOptions.serviceAccountName | default (include "solr.serviceAccountName.global" .) }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for Solr
+*/}}
+{{- define "solr.serviceAccountName.zk" -}}
+{{ .Values.zk.provided.zookeeperPodPolicy | default (include "solr.serviceAccountName.global" .) }}
+{{- end -}}
+
+{{/*
 ZK ChRoot
 */}}
 {{ define "solr.zk.chroot" }}

--- a/helm/solr/templates/_helpers.tpl
+++ b/helm/solr/templates/_helpers.tpl
@@ -89,17 +89,3 @@ Create the name of the service account to use for Solr
 {{- define "solr.serviceAccountName.solr" -}}
 {{ .Values.podOptions.serviceAccountName | default (include "solr.serviceAccountName.global" .) }}
 {{- end -}}
-
-{{/*
-Create the name of the service account to use for Solr
-*/}}
-{{- define "solr.serviceAccountName.zk" -}}
-{{ .Values.zk.provided.zookeeperPodPolicy | default (include "solr.serviceAccountName.global" .) }}
-{{- end -}}
-
-{{/*
-ZK ChRoot
-*/}}
-{{ define "solr.zk.chroot" }}
-/{{ printf "%s%s" (trimSuffix "/" .Values.zk.chroot) (ternary (printf "/%s/%s" .Release.Namespace (include "solr.fullname" .)) "" .Values.zk.uniqueChroot) | trimPrefix "/" }}
-{{ end }}

--- a/helm/solr/templates/_zk_helpers.tpl
+++ b/helm/solr/templates/_zk_helpers.tpl
@@ -1,0 +1,64 @@
+{{/*
+   * Licensed to the Apache Software Foundation (ASF) under one or more
+   * contributor license agreements.  See the NOTICE file distributed with
+   * this work for additional information regarding copyright ownership.
+   * The ASF licenses this file to You under the Apache License, Version 2.0
+   * (the "License"); you may not use this file except in compliance with
+   * the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */}}
+
+{{/*
+Create the name of the service account to use for ZK
+*/}}
+{{- define "solr.serviceAccountName.zk" -}}
+{{- .Values.zk.provided.zookeeperPodPolicy.serviceAccountName | default (include "solr.serviceAccountName.global" .) -}}
+{{- end -}}
+
+{{/*
+Print all ZK Pod Options.
+This is tricky because we want to default the serviceAccountName if not specified, but want to keep it empty if nothing is provided.
+*/}}
+{{- define "solr.zk.zookeeperPodPolicy" -}}
+{{- if (include "solr.serviceAccountName.zk" .) -}}
+{{ merge .Values.zk.provided.zookeeperPodPolicy (dict "serviceAccountName" (include "solr.serviceAccountName.zk" .)) | toYaml }}
+{{- else if .Values.zk.provided.zookeeperPodPolicy -}}
+{{ toYaml .Values.zk.provided.zookeeperPodPolicy }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print all ZK Pod Options
+*/}}
+{{- define "solr.zk.zookeeperPodPolicy.serviceAccountName.tmp" -}}
+{{- if .Values.zk.provided.zookeeperPodPolicy.serviceAccountName -}}
+serviceAccountName: {{ .Values.zk.provided.zookeeperPodPolicy.serviceAccountName }}
+{{- else if (include "solr.serviceAccountName.zk" .) -}}
+serviceAccountName: {{ include "solr.serviceAccountName.zk" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print all ZK Pod Options
+*/}}
+{{- define "solr.zk.zookeeperPodPolicy.serviceAccountName" -}}
+{{- if .Values.zk.provided.zookeeperPodPolicy.serviceAccountName -}}
+{{- .Values.zk.provided.zookeeperPodPolicy.serviceAccountName -}}
+{{- else if (include "solr.serviceAccountName.zk" .) -}}
+{{- include "solr.serviceAccountName.zk" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ZK ChRoot
+*/}}
+{{ define "solr.zk.chroot" }}
+/{{ printf "%s%s" (trimSuffix "/" .Values.zk.chroot) (ternary (printf "/%s/%s" .Release.Namespace (include "solr.fullname" .)) "" .Values.zk.uniqueChroot) | trimPrefix "/" }}
+{{ end }}

--- a/helm/solr/templates/service_account.yaml
+++ b/helm/solr/templates/service_account.yaml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "solr.serviceAccountName" . }}
+{{- end }}

--- a/helm/solr/templates/service_account.yaml
+++ b/helm/solr/templates/service_account.yaml
@@ -17,5 +17,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "solr.serviceAccountName" . }}
+  name: {{ include "solr.serviceAccountName.global" . }}
 {{- end }}

--- a/helm/solr/templates/solrcloud.yaml
+++ b/helm/solr/templates/solrcloud.yaml
@@ -186,9 +186,9 @@ spec:
       persistence:
         {{- toYaml .Values.zk.provided.persistence | nindent 8 }}
       {{- end }}
-      {{- if .Values.zk.provided.zookeeperPodPolicy }}
+      {{- if (include "solr.zk.zookeeperPodPolicy" .) }}
       zookeeperPodPolicy:
-        {{- toYaml .Values.zk.provided.zookeeperPodPolicy | nindent 8 }}
+        {{- include "solr.zk.zookeeperPodPolicy" . | nindent 8 }}
       {{- end }}
       {{- if .Values.zk.acl }}
       acl:

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -27,6 +27,15 @@ global:
   imagePullSecrets: []
   clusterDomain: ""
 
+# Use a serviceAccount for all pods created under this chart (Solr and ZK)
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: false
+  # The name of the ServiceAccount to use.
+  # Required if create is false.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 image:
   repository: "solr"
   tag: "8.8.2"
@@ -149,6 +158,8 @@ zk:
       # nodeSelector: {}
       # env: []
       # resources: {}
+      # # Set ZK service account individually instead of the global "serviceAccount.name"
+      # serviceAccountName: ""
 
   # Use this section to inject ACL information for your zookeeper from a Kube secret in the same namespace as your SolrCloud
   acl: {}
@@ -192,7 +203,6 @@ podOptions:
   sidecarContainers: []
   initContainers: []
 
-  serviceAccountName: ""
   priorityClassName: ""
   envVars: []
   affinity: {}
@@ -200,6 +210,9 @@ podOptions:
   nodeSelector: {}
   podSecurityContext: {}
   terminationGracePeriodSeconds: null
+
+  # Set Solr service account individually instead of the global "serviceAccount.name"
+  serviceAccountName: ""
 
   # Probes for the Solr pods
   livenessProbe: {}

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -192,6 +192,7 @@ podOptions:
   sidecarContainers: []
   initContainers: []
 
+  serviceAccountName: ""
   priorityClassName: ""
   envVars: []
   affinity: {}


### PR DESCRIPTION
Resolves #264 

The option will be available for:
- SolrCloud pods
- Provided ZK Cluster pods
- SolrPrometheusExporter pods

**SolrCloud CRD**
```yaml
spec:
  customSolrKubeOptions:
    podOptions:
      serviceAccountName: "...."
  zookeeperRef:
    provided:
      zookeeperPodPolicy:
        serviceAccountName: "...."
```

**SolrPrometheusExporter CRD**
```yaml
spec:
  customKubeOptions:
    podOptions:
      serviceAccountName: "...."
```

This is enabled multiple places in the **Solr Helm Chart**:

```yaml
# Set the default service account for all pods (Solr & ZK)
# Will be overriden if Solr or ZK Specific options are provided below
serviceAccount:
  # Create a service account with the following name, with the helm deployment name as the default
  create: false
  name: ""

# Option for only setting the Solr Pod service account
podOptions:
  serviceAccountName: ""

# Option for only setting the ZK Pod service account
zk:
  provided:
    zookeeperPodPolicy:
      serviceAccountName: ""
```