### PR TITLE
Upgrade default Solr version to 8.9

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -35,7 +35,7 @@ const (
 
 	DefaultSolrReplicas = int32(3)
 	DefaultSolrRepo     = "library/solr"
-	DefaultSolrVersion  = "7.7.0"
+	DefaultSolrVersion  = "8.9"
 	DefaultSolrStorage  = "5Gi"
 	DefaultSolrJavaMem  = "-Xms1g -Xmx2g"
 	DefaultSolrOpts     = ""

--- a/controllers/solrcloud_controller_tls_test.go
+++ b/controllers/solrcloud_controller_tls_test.go
@@ -356,7 +356,7 @@ func expectStatefulSetTLSConfig(t *testing.T, g *gomega.GomegaWithT, sc *solr.So
 	if sc.Spec.SolrTLS != nil {
 		assert.NotNil(t, zkSetupInitContainer, "Didn't find the zk-setup InitContainer in the sts!")
 		if zkSetupInitContainer != nil {
-			assert.Equal(t, "library/solr:7.7.0", zkSetupInitContainer.Image)
+			assert.Equal(t, stateful.Spec.Template.Spec.Containers[0].Image, zkSetupInitContainer.Image, "The zk-setup init container should use the same image as the Solr container")
 			assert.Equal(t, 3, len(zkSetupInitContainer.Command), "Wrong command length for zk-setup init container")
 			assert.Contains(t, zkSetupInitContainer.Command[2], expCmd, "ZK Setup command does not set urlScheme")
 			expNumVars := 3

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -53,6 +53,12 @@ _Note that the Helm chart version does not contain a `v` prefix, which the downl
 
 ## Upgrade Warnings and Notes
 
+### v0.4.0
+- The default Solr version for `SolrCloud` and `SolrPrometheusExporter` resources has been upgraded from `7.7.0` to `8.9`.
+  This will not effect any existing resources, as default versions are hard-written to the resources immediately.
+  Only new resources created after the Solr Operator is upgraded to `v0.4.0` will be affected.
+
+
 ### v0.3.0
 - All deprecated CRD fields and Solr Operator options from `v0.2.*` have been removed.
 

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -67,7 +67,7 @@ annotations:
         - name: Github Issue
           url: https://github.com/apache/solr-operator/issues/285
         - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/279
+          url: https://github.com/apache/solr-operator/pull/287
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -61,6 +61,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/281
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/279
+    - kind: changed
+      description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/285
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/279
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -48,6 +48,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/112
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/276
+    - kind: changed
+      description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/285
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/287
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -29,7 +29,7 @@ global:
 
 image:
   repository: "solr"
-  tag: "8.8.2"
+  tag: ""
   # Default pullPolicy is empty, which is Always for "latest" tags and IfNotPresent for all others.
   pullPolicy: ""
   imagePullSecret: ""


### PR DESCRIPTION
Resolves #285

Upgrades the default Solr version to `8.9` from `7.7.0`.

No existing `SolrCloud` or `SolrPrometheusExporter` resources will be effected by this change, only new resources created after the Solr Operator is upgraded.