### PR TITLE
Change base image of Solr Operator to distroless/static

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -57,7 +57,7 @@ RUN CGO_ENABLED=0 GIT_SHA="${GIT_SHA}" make fetch-licenses-full build
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Debug is needed, so that the license files are viewable.
 # If there is another way to view these files, we can remove "debug-".
-FROM gcr.io/distroless/base:debug-nonroot
+FROM gcr.io/distroless/static:debug-nonroot
 
 WORKDIR /
 COPY --from=builder workspace/bin/solr-operator .

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -91,6 +91,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/259
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/284
+    - kind: security
+      description: Changed Solr Operator base Docker image to reduce vulnerabilities.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/294
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/295
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease


### PR DESCRIPTION
Resolves #294

I reached my limit of `docker scan` for this month, but the base image has no vulnerabilities, so we should be down to 2 given the vulnerabilities listed for the solr-operator binary here:

https://artifacthub.io/packages/helm/apache-solr/solr-operator?modal=security-report

The difference between `distroless/base` and `distroless/static` is mainly for the purpose of [including `libc`](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md) for go programs that use `cgo`, [such as through the `net` package](https://pkg.go.dev/net#hdr-Name_Resolution).

Since the Solr Operator is built with `CGO_ENABLED=false`, we do not need `libc`, so we should be find to base our image on `distroless/static`.