### PR TITLE
Ability to customize probes for the PrometheusExporter

### DIFF
--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/apache/solr-operator/controllers/util"
 	zkv1beta1 "github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -392,11 +391,11 @@ func testGenericPodEnvVariables(t *testing.T, expectedEnvVars map[string]string,
 }
 
 func testPodTolerations(t *testing.T, expectedTolerations []corev1.Toleration, foundTolerations []corev1.Toleration) {
-	assert.True(t, reflect.DeepEqual(expectedTolerations, foundTolerations), "Expected tolerations and found tolerations don't match")
+	assert.EqualValues(t, expectedTolerations, foundTolerations, "Expected tolerations and found tolerations don't match")
 }
 
-func testPodProbe(t *testing.T, expectedProbe *corev1.Probe, foundProbe *corev1.Probe) {
-	assert.True(t, reflect.DeepEqual(expectedProbe, foundProbe), "Expected probe and found probe don't match")
+func testPodProbe(t *testing.T, expectedProbe *corev1.Probe, foundProbe *corev1.Probe, probeType string) {
+	assert.EqualValuesf(t, expectedProbe, foundProbe, "Incorrect default container %s probe", probeType)
 }
 
 func testMapsEqual(t *testing.T, mapName string, expected map[string]string, found map[string]string) {

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -294,8 +294,9 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 	}
 	testMapsEqual(t, "pod annotations", util.MergeLabelsOrAnnotations(map[string]string{"solr.apache.org/solrXmlMd5": fmt.Sprintf("%x", md5.Sum([]byte(configMap.Data["solr.xml"])))}, testPodAnnotations), statefulSet.Spec.Template.Annotations)
 	testMapsEqual(t, "pod node selectors", testNodeSelectors, statefulSet.Spec.Template.Spec.NodeSelector)
-	testPodProbe(t, testProbeLivenessNonDefaults, statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe)
-	testPodProbe(t, testProbeReadinessNonDefaults, statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe)
+	testPodProbe(t, testProbeLivenessNonDefaults, statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe, "liveness")
+	testPodProbe(t, testProbeReadinessNonDefaults, statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe, "readiness")
+	testPodProbe(t, testProbeStartup, statefulSet.Spec.Template.Spec.Containers[0].StartupProbe, "startup")
 	assert.Equal(t, []string{"solr", "stop", "-p", "8983"}, statefulSet.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command, "Incorrect pre-stop command")
 	testPodTolerations(t, testTolerations, statefulSet.Spec.Template.Spec.Tolerations)
 	assert.EqualValues(t, testPriorityClass, statefulSet.Spec.Template.Spec.PriorityClassName, "Incorrect Priority class name for Pod Spec")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -51,6 +51,14 @@ var additionalLables = map[string]string{
 }
 
 func TestMain(m *testing.M) {
+	// TODO: We can probably remove this once we upgrade our minimum supported version of Kubernetes
+	customApiServerFlags := []string{
+		"--feature-gates=StartupProbe=true",
+	}
+
+	apiServerFlags := append([]string(nil), envtest.DefaultKubeAPIServerFlags...)
+	apiServerFlags = append(apiServerFlags, customApiServerFlags...)
+
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{
@@ -58,6 +66,7 @@ func TestMain(m *testing.M) {
 			filepath.Join("..", "config", "dependencies"),
 		},
 		AttachControlPlaneOutput: false, // set to true to get more logging from the control plane
+		KubeAPIServerFlags:       apiServerFlags,
 	}
 	solrv1beta1.AddToScheme(scheme.Scheme)
 	zkOp.AddToScheme(scheme.Scheme)

--- a/controllers/util/common.go
+++ b/controllers/util/common.go
@@ -132,6 +132,35 @@ func IsPVCOrphan(pvcName string, replicas int32) bool {
 	return int32(ordinal) >= replicas
 }
 
+// customizeProbe builds the probe logic used for pod liveness, readiness, startup checks
+func customizeProbe(initialProbe *corev1.Probe, customProbe corev1.Probe) *corev1.Probe {
+	if customProbe.InitialDelaySeconds != 0 {
+		initialProbe.InitialDelaySeconds = customProbe.InitialDelaySeconds
+	}
+
+	if customProbe.TimeoutSeconds != 0 {
+		initialProbe.TimeoutSeconds = customProbe.TimeoutSeconds
+	}
+
+	if customProbe.SuccessThreshold != 0 {
+		initialProbe.SuccessThreshold = customProbe.SuccessThreshold
+	}
+
+	if customProbe.FailureThreshold != 0 {
+		initialProbe.FailureThreshold = customProbe.FailureThreshold
+	}
+
+	if customProbe.PeriodSeconds != 0 {
+		initialProbe.PeriodSeconds = customProbe.PeriodSeconds
+	}
+
+	if customProbe.Handler.Exec != nil || customProbe.Handler.HTTPGet != nil || customProbe.Handler.TCPSocket != nil {
+		initialProbe.Handler = customProbe.Handler
+	}
+
+	return initialProbe
+}
+
 // CopyConfigMapFields copies the owned fields from one ConfigMap to another
 func CopyConfigMapFields(from, to *corev1.ConfigMap, logger logr.Logger) bool {
 	logger = logger.WithValues("kind", "configMap")

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -91,6 +91,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/259
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/284
+    - kind: added
+      description: Ability to customize probes for PrometheusExporter
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/282
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/297
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease


### PR DESCRIPTION
Resolves #282 

I also went ahead and simplified the way that Probe customization is done in the code. Startup Probes are now tested as well, as apparently they had not been tested previously.