### PR TITLE
Add artifactHub validation in helm-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,8 @@ check-generated:
 
 check-helm:
 	helm lint helm/*
+	# Check that the ArtifactHub Metadata is correct
+	docker run --rm --name artifact-hub-check -v "${PWD}/helm:/etc/helm" artifacthub/ah ah lint -k helm -p /etc/helm
 
 check-mod:
 	rm -rf generated-check


### PR DESCRIPTION
Resolves #296

Now that the ArtifactHub `ah` validation tool is official, we can add ArtifactHub validation to our `make helm-check`, thus ensuring that all changes made to the helm charts are safe with regards to the ArtifactHub metadata!