### PR TITLE
Fix initial security.json rbap rules

### DIFF
--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -1341,12 +1341,13 @@ func generateSecurityJson(solrCloud *solr.SolrCloud) map[string][]byte {
           %s,
           { "name": "k8s-status", "role":"k8s", "collection": null, "path":"/admin/collections" },
           { "name": "k8s-metrics", "role":"k8s", "collection": null, "path":"/admin/metrics" },
+          { "name": "k8s-zk", "role":"k8s", "collection": null, "path":"/admin/zookeeper/status" },
           { "name": "k8s-ping", "role":"k8s", "collection": "*", "path":"/admin/ping" },
-          { "name": "all", "role":["admin","users"] },
           { "name": "read", "role":["admin","users"] },
           { "name": "update", "role":["admin"] },
           { "name": "security-read", "role": "admin"},
-          { "name": "security-edit", "role": "admin"}
+          { "name": "security-edit", "role": "admin"},
+          { "name": "all", "role":["admin"] }
         ]
       }
     }`, blockUnknown, credentialsJson, username, probeAuthz)

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -1345,8 +1345,8 @@ func generateSecurityJson(solrCloud *solr.SolrCloud) map[string][]byte {
           { "name": "k8s-ping", "role":"k8s", "collection": "*", "path":"/admin/ping" },
           { "name": "read", "role":["admin","users"] },
           { "name": "update", "role":["admin"] },
-          { "name": "security-read", "role": "admin"},
-          { "name": "security-edit", "role": "admin"},
+          { "name": "security-read", "role": ["admin"] },
+          { "name": "security-edit", "role": ["admin"] },
           { "name": "all", "role":["admin"] }
         ]
       }

--- a/docs/solr-cloud/solr-cloud-crd.md
+++ b/docs/solr-cloud/solr-cloud-crd.md
@@ -792,15 +792,17 @@ Take a moment to review these authorization rules so that you're aware of the ro
         "collection": null,
         "path": "/admin/metrics"
       },
+      { 
+         "name": "k8s-zk", 
+         "role":"k8s", 
+         "collection": null, 
+         "path":"/admin/zookeeper/status" 
+      },
       {
         "name": "k8s-ping",
         "role": "k8s",
         "collection": "*",
         "path": "/admin/ping"
-      },
-      {
-        "name": "all",
-        "role": [ "admin", "users" ]
       },
       {
         "name": "read",
@@ -812,11 +814,15 @@ Take a moment to review these authorization rules so that you're aware of the ro
       },
       {
         "name": "security-read",
-        "role": "admin"
+        "role": [ "admin" ]
       },
       {
         "name": "security-edit",
-        "role": "admin"
+        "role": [ "admin" ]
+      },
+      {
+        "name": "all",
+        "role": [ "admin" ]
       }
     ]
   }
@@ -863,6 +869,10 @@ The exporter also hits the `/admin/ping` endpoint for every collection, which re
       },
 ```
 The `"collection":"*"` setting indicates this path applies to all collections, which maps to endpoint `/collections/<COLL>/admin/ping` at runtime.
+
+The initial authorization config grants the `read` permission to the `users` role, which allows `users` to send query requests but cannot add / update / delete documents.
+For instance, the `solr` user is mapped to the `users` role, so the `solr` user can send query requests only. 
+In general, please verify the initial authorization rules for each role before sharing user credentials.
 
 ### Option 2: User-provided Basic Auth Secret
 

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -105,6 +105,20 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/282
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/297
+    - kind: security
+      description: Remove users role from the all permission in the initial security.json
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/274
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/299
+    - kind: fixed
+      description: Grant access to the /admin/zookeeper/status path to the k8s role in the initial security.json
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/289
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/299
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease


### PR DESCRIPTION
Fixes #274 and #289 

Very minor change to remove the `users` role from the `all` permission, move the `all` permission to the last index in the json file, and add a new rule for the `/admin/zookeeper/status` path needed for updates to the exporter in 8.9 (see #289 )

Manual integration-style testing required:
Create a SolrCloud running Apache Solr 8.9.0, created a collection, and then tried to index some docs as the `solr` user, which now fails with a 403 ~ Unauthorized. Indexing as the `admin` user works. The `solr` user can log in to the Admin UI but can only query collections. 

Also verified the Prometheus exporter (also running 8.9) can now retrieve metrics when basic auth is enabled.