### PR TITLE
Option to watch for updates to the mTLS cert used by the operator to call Solr pods

### DIFF
--- a/build/NOTICE-ADDITION
+++ b/build/NOTICE-ADDITION
@@ -1,6 +1,9 @@
 This project uses the hashicorp/golang-lru project, which is MPL 2.0 licensed. The source code can be found at
     https://github.com/hashicorp/golang-lru
 
+This project uses the runtime dependency https://github.com/fsnotify/fsnotify, which is BSD-3 licensed.
+See the below notice, provided by the project.
+
 =================================================
 ==  FSNotify Notice                            ==
 =================================================

--- a/build/NOTICE-ADDITION
+++ b/build/NOTICE-ADDITION
@@ -1,2 +1,5 @@
 This project uses the hashicorp/golang-lru project, which is MPL 2.0 licensed. The source code can be found at
     https://github.com/hashicorp/golang-lru
+
+This project uses the fsnotify/fsnotify library, which is BSD 3-Clause "New" or "Revised" licensed. The source code can be found at
+    https://github.com/fsnotify/fsnotify

--- a/build/NOTICE-ADDITION
+++ b/build/NOTICE-ADDITION
@@ -1,5 +1,34 @@
 This project uses the hashicorp/golang-lru project, which is MPL 2.0 licensed. The source code can be found at
     https://github.com/hashicorp/golang-lru
 
-This project uses the fsnotify/fsnotify library, which is BSD 3-Clause "New" or "Revised" licensed. The source code can be found at
-    https://github.com/fsnotify/fsnotify
+=================================================
+==  FSNotify Notice                            ==
+=================================================
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/controllers/util/solr_api/api.go
+++ b/controllers/util/solr_api/api.go
@@ -39,9 +39,6 @@ func SetNoVerifyTLSHttpClient(client *http.Client) {
 }
 
 func SetMTLSHttpClient(client *http.Client) {
-	if mTLSHttpClient != nil {
-		mTLSHttpClient.CloseIdleConnections()
-	}
 	mTLSHttpClient = client
 }
 

--- a/controllers/util/solr_api/api.go
+++ b/controllers/util/solr_api/api.go
@@ -39,6 +39,9 @@ func SetNoVerifyTLSHttpClient(client *http.Client) {
 }
 
 func SetMTLSHttpClient(client *http.Client) {
+	if mTLSHttpClient != nil {
+		mTLSHttpClient.CloseIdleConnections()
+	}
 	mTLSHttpClient = client
 }
 

--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -141,3 +141,6 @@ The CA certificate needs to be stored in Kubernetes secret in PEM format and pro
 
 In most cases, you'll also want to configure the operator with `mTLS.insecureSkipVerify=true` (the default) as you'll want the operator to skip hostname verification for Solr pods.
 Setting `mTLS.insecureSkipVerify` to `false` means the operator will enforce hostname verification for the certificate provided by Solr pods.
+
+By default, the operator watches for updates to the mTLS client certificate (mounted from the `mTLS.clientCertSecret` secret) and then refreshes the HTTP client to use the updated certificate.
+To disable this behavior, configure the operator using: `--set mTLS.watchForUpdates=false`.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -156,6 +156,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/290
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/311
+    - kind: added
+      description: Option to watch for updates to the mTLS client certificate used by the operator to call Solr pods.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/317
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/318
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.4.0-prerelease

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -163,6 +163,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | mTLS.caCertSecretKey | string | `""` | Name of a Kubernetes secret, in the same namespace, that contains PEM encoded Root CA Certificate to use when connecting to Solr with Client Auth. |
 | mTLS.caCertSecret | string | `""` | Name of the key in the `caCertSecret` that contains the Root CA Cert as a value. |
 | mTLS.insecureSkipVerify | boolean | `true` | Skip server certificate and hostname verification when connecting to Solr with ClientAuth. |
+| mTLS.watchForUpdates | boolean | `true` | Watch for updates to the mTLS certificate to reload the HTTP client used to call Solr pods with an updated client certificate. |
 
 ### Running the Solr Operator
 

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
         {{- if .Values.mTLS.insecureSkipVerify }}
         - --tls-skip-verify-server={{ .Values.mTLS.insecureSkipVerify }}
         {{- end }}
+        {{- if .Values.mTLS.watchForUpdates }}
+        - --tls-watch-cert={{ .Values.mTLS.watchForUpdates }}
+        {{- end }}
+
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -64,9 +64,7 @@ spec:
         {{- if .Values.mTLS.insecureSkipVerify }}
         - --tls-skip-verify-server={{ .Values.mTLS.insecureSkipVerify }}
         {{- end }}
-        {{- if .Values.mTLS.watchForUpdates }}
         - --tls-watch-cert={{ .Values.mTLS.watchForUpdates }}
-        {{- end }}
 
         env:
           - name: POD_NAMESPACE

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -76,3 +76,4 @@ mTLS:
   caCertSecret: ""
   caCertSecretKey: ca-cert.pem
   insecureSkipVerify: true
+  watchForUpdates: true


### PR DESCRIPTION
Fixes #317 

Use `fsnotify` to watch the mTLS `tls.crt` file (mounted from a secret) to hot reload the certificate for the Http client used to make calls to Solr.

For files loaded from a secret, the watched file will be a symlink that gets removed and re-added when the underlying secret changes. Thus, our watcher responds to a REMOVE event on the symlink to reload the certificate. It also supports a WRITE event if the watched file is not a symlink, which is probably not needed right now but may be useful in the future when TLS certs get loaded from a CSI driver or other type mechanism.

Manual testing for now by configuring a self-signed cert for the operator pod and then updating it via cert-manager, which triggers the cert to get re-issued and the secret to get updated. K8s handles updating the files on the pod when the secret updates. Here's some logging from a test run:
```
2021-08-31T20:58:22.783Z	INFO	setup	Received fsnotify event:	{"event": "\"/etc/ssl/solr/client-cert/tls.crt\": REMOVE"}

2021-08-31T20:58:22.783Z	INFO	setup	mTLS cert file updated	{"certPath": "/etc/ssl/solr/client-cert/tls.crt", "certFile": "/etc/ssl/solr/client-cert/..2021_08_31_20_58_22.684994880/tls.crt"}

2021-08-31T20:58:22.783Z	INFO	setup	Configured the custom CA pem for the mTLS transport	{"path": "/etc/ssl/solr/ca-cert/rootSolrCert.pem"}

2021-08-31T20:58:22.783Z	INFO	setup	Updated mTLS Http Client after update to cert	{"certPath": "/etc/ssl/solr/client-cert/tls.crt"}

2021-08-31T20:58:22.783Z	INFO	setup	Re-added watch for symlink to mTLS cert file	{"certPath": "/etc/ssl/solr/client-cert/tls.crt", "certFile": "/etc/ssl/solr/client-cert/..2021_08_31_20_58_22.684994880/tls.crt"}

2021-08-31T20:58:36.153Z	INFO	controllers.SolrCloud	Updating SolrCloud Status	
```
