### PR TITLE
Enable Solr Operator metrics when using the helm chart.

### DIFF
--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -148,6 +148,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/355
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/356
+    - kind: added
+      description: Export default Solr Operator metrics, and enable when using the Helm chart
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/307
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/360
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.5.0-prerelease

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -158,6 +158,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | watchNamespaces | string | `""` | A comma-separated list of namespaces that the solr operator should watch. If empty, the solr operator will watch all namespaces in the cluster. If set to `true`, this will be populated with the namespace that the operator is deployed to. |
 | zookeeper-operator.install | boolean | `true` | This option installs the Zookeeper Operator as a helm dependency |
+| metrics.enable | boolean | `true` | Enable metrics for the Solr Operator. Will be available via the "metrics"/8080 port. |
 | zookeeper-operator.use | boolean | `false` | This option enables the use of provided Zookeeper instances for SolrClouds via the Zookeeper Operator, without installing the Zookeeper Operator as a dependency. If `zookeeper-operator.install`=`true`, then this option is ignored. |
 | mTLS.clientCertSecret | string | `""` | Name of a Kubernetes TLS secret, in the same namespace, that contains a Client certificate to load into the operator. If provided, this is used when communicating with Solr. |
 | mTLS.caCertSecretKey | string | `""` | Name of a Kubernetes secret, in the same namespace, that contains PEM encoded Root CA Certificate to use when connecting to Solr with Client Auth. |

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -158,7 +158,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | watchNamespaces | string | `""` | A comma-separated list of namespaces that the solr operator should watch. If empty, the solr operator will watch all namespaces in the cluster. If set to `true`, this will be populated with the namespace that the operator is deployed to. |
 | zookeeper-operator.install | boolean | `true` | This option installs the Zookeeper Operator as a helm dependency |
-| metrics.enable | boolean | `true` | Enable metrics for the Solr Operator. Will be available via the "metrics"/8080 port. |
+| metrics.enable | boolean | `true` | Enable metrics for the Solr Operator. Will be available via the "metrics"/8080 port on the solr operator pods under the "/metrics" path. |
 | zookeeper-operator.use | boolean | `false` | This option enables the use of provided Zookeeper instances for SolrClouds via the Zookeeper Operator, without installing the Zookeeper Operator as a dependency. If `zookeeper-operator.install`=`true`, then this option is ignored. |
 | mTLS.clientCertSecret | string | `""` | Name of a Kubernetes TLS secret, in the same namespace, that contains a Client certificate to load into the operator. If provided, this is used when communicating with Solr. |
 | mTLS.caCertSecretKey | string | `""` | Name of a Kubernetes secret, in the same namespace, that contains PEM encoded Root CA Certificate to use when connecting to Solr with Client Auth. |

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
         - --tls-skip-verify-server={{ .Values.mTLS.insecureSkipVerify }}
         {{- end }}
         - --tls-watch-cert={{ .Values.mTLS.watchForUpdates }}
+        - "--health-probe-bind-address=:8081"
+        {{- if .Values.metrics.enable }}
+        - "--metrics-bind-address=:8080"
+        {{- end }}
 
         env:
           - name: POD_NAMESPACE
@@ -101,6 +105,12 @@ spec:
         {{- if (include "solr-operator.mTLS.volumeMounts" .) }}
         volumeMounts:
           {{- include "solr-operator.mTLS.volumeMounts" .  | nindent 10 }}
+        {{- end }}
+
+        {{- if .Values.metrics.enable }}
+        ports:
+          - containerPort: 8080
+            name: metrics
         {{- end }}
       {{- if (include "solr-operator.mTLS.volumes" .) }}
       volumes:

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -77,3 +77,7 @@ mTLS:
   caCertSecretKey: ca-cert.pem
   insecureSkipVerify: true
   watchForUpdates: true
+
+# Enable metrics for the Solr Operator
+metrics:
+  enable: true


### PR DESCRIPTION
Resolves #307 

This does not use the protected metrics-endpoint described in the [kubebuilder docs](https://kubebuilder.io/reference/metrics.html#protecting-the-metrics). This is also just using the default operator metrics. We can add additional metrics in future PRs.

The metrics have been enabled since #321 was implemented, but not when using the helm chart. This fixes that.