### PR TITLE
Properly resolve the name of the basic auth secret for a SolrCloud when calling the backup API

### DIFF
--- a/controllers/solrbackup_controller.go
+++ b/controllers/solrbackup_controller.go
@@ -179,7 +179,7 @@ func (r *SolrBackupReconciler) reconcileSolrCloudBackup(ctx context.Context, bac
 
 	// Add any additional values needed to Authn to Solr to the Context used when invoking the API
 	if solrCloud.Spec.SolrSecurity != nil {
-		ctx, err = util.AddAuthToContext(ctx, &r.Client, solrCloud.Spec.SolrSecurity, solrCloud.Namespace)
+		ctx, err = util.AddAuthToContext(ctx, &r.Client, solrCloud)
 		if err != nil {
 			return nil, actionTaken, err
 		}

--- a/controllers/util/solr_security_util.go
+++ b/controllers/util/solr_security_util.go
@@ -221,11 +221,11 @@ func (security *SecurityConfig) AddAuthToContext(ctx context.Context) (context.C
 }
 
 // Similar to security.AddAuthToContext but we need to lookup the secret containing the authn credentials first
-func AddAuthToContext(ctx context.Context, client *client.Client, solrSecurity *solr.SolrSecurityOptions, ns string) (context.Context, error) {
-	reader := *client
-	if solrSecurity.AuthenticationType == solr.Basic {
+func AddAuthToContext(ctx context.Context, client *client.Client, solrCloud *solr.SolrCloud) (context.Context, error) {
+	if solrCloud.Spec.SolrSecurity != nil && solrCloud.Spec.SolrSecurity.AuthenticationType == solr.Basic {
+		reader := *client
 		basicAuthSecret := &corev1.Secret{}
-		if err := reader.Get(ctx, types.NamespacedName{Name: solrSecurity.BasicAuthSecret, Namespace: ns}, basicAuthSecret); err != nil {
+		if err := reader.Get(ctx, types.NamespacedName{Name: solrCloud.BasicAuthSecretName(), Namespace: solrCloud.Namespace}, basicAuthSecret); err != nil {
 			return nil, err
 		}
 		return contextWithBasicAuthHeader(ctx, basicAuthSecret), nil


### PR DESCRIPTION
Was a bug introduced when refactoring the security code, basically need to call the `solrCloud.BasicAuthSecretName()` method. Tested in live EKS cluster and backup API requests are now working.
