### PR TITLE
Move runAsNonRoot to container securityContext.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,8 +37,6 @@ spec:
       labels:
         control-plane: solr-operator
     spec:
-      securityContext:
-        runAsNonRoot: true
       containers:
       - args:
         - --leader-elect
@@ -47,6 +45,7 @@ spec:
         name: solr-operator
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -61,6 +61,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/387
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/388
+    - kind: fixed
+      description: Solr Operator helm chart now sets runAsNonRoot only on the solr operator container. Sidecars can run as root.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/389
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/395
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.6.0-prerelease

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
         {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}
     spec:
-      securityContext:
-        runAsNonRoot: true
       serviceAccountName: {{ include "solr-operator.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
@@ -92,6 +90,7 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Fixes #389 

This was previously specified on the Solr Operator pod, meaning that all sidecar containers also had to run as non-root, although that might not be possible. To make this work as best as possible for everyone, we only know that the Solr Operator image uses a non-root user, so we will only specify this option on the Solr Operator container.