### PR TITLE
Add operator version & ArgoCD annotations to CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ prepare: fmt generate manifests fetch-licenses-list mod-tidy ## Prepare the code
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects
 	rm -rf generated-check/api
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=solr-operator-role webhook paths="./api/..." paths="./controllers/." output:rbac:artifacts:config=$(or $(TMP_CONFIG_OUTPUT_DIRECTORY),config)/rbac output:crd:artifacts:config=$(or $(TMP_CONFIG_OUTPUT_DIRECTORY),config)/crd/bases
+	CONFIG_DIRECTORY=$(or $(TMP_CONFIG_OUTPUT_DIRECTORY),config) VERSION=$(VERSION) ./hack/config/add_crds_annotations.sh
 	CONFIG_DIRECTORY=$(or $(TMP_CONFIG_OUTPUT_DIRECTORY),config) HELM_DIRECTORY=$(or $(TMP_HELM_OUTPUT_DIRECTORY),helm) ./hack/config/copy_crds_roles_helm.sh
 	CONFIG_DIRECTORY=$(or $(TMP_CONFIG_OUTPUT_DIRECTORY),config) ./hack/config/add_crds_roles_headers.sh
 

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrbackups.solr.apache.org
 spec:

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrbackups.solr.apache.org

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrclouds.solr.apache.org

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrclouds.solr.apache.org
 spec:

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrprometheusexporters.solr.apache.org
 spec:

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -19,6 +19,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrprometheusexporters.solr.apache.org

--- a/config/dependencies/zookeeper_cluster_crd.yaml
+++ b/config/dependencies/zookeeper_cluster_crd.yaml
@@ -14,6 +14,7 @@ kind: CustomResourceDefinition
 metadata:
   name: zookeeperclusters.zookeeper.pravega.io
   annotations:
+    operator.zookeeper.pravega.io/version: v0.2.13
     argocd.argoproj.io/sync-options: Replace=true
 spec:
   group: zookeeper.pravega.io

--- a/config/dependencies/zookeeper_cluster_crd.yaml
+++ b/config/dependencies/zookeeper_cluster_crd.yaml
@@ -13,6 +13,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: zookeeperclusters.zookeeper.pravega.io
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   group: zookeeper.pravega.io
   names:

--- a/hack/config/add_crds_annotations.sh
+++ b/hack/config/add_crds_annotations.sh
@@ -30,9 +30,8 @@ files=("${CONFIG_DIRECTORY:-config}"/crd/bases/*)
 # Copy and package CRDs
 for file in "${files[@]}"; do
   {
-    cat "${file}" | sed -E "/^    controller-gen.kubebuilder.io.version.*/a \\
+    cat "${file}" | sed -e "/^    controller-gen.kubebuilder.io.version.*/a \\
     operator.solr.apache.org\\/version: ${VERSION}\\
-    argocd.argoproj.io\\/sync-options: Replace=true\\
-"
+    argocd.argoproj.io\\/sync-options: Replace=true"
   } > "${file}.tmp" && mv "${file}.tmp" "${file}"
 done

--- a/hack/config/add_crds_annotations.sh
+++ b/hack/config/add_crds_annotations.sh
@@ -21,17 +21,18 @@ set -o pipefail
 # error on unset variables
 set -u
 
-echo "Add headers to CRDs and Role files"
+echo "Add annotations to CRDs"
 
-rm -rf "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp "${CONFIG_DIRECTORY:-config}"/rbac/role.yaml.tmp
+rm -rf "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp
 
-files=("${CONFIG_DIRECTORY:-config}"/crd/bases/* "${CONFIG_DIRECTORY:-config}"/rbac/role.yaml)
+files=("${CONFIG_DIRECTORY:-config}"/crd/bases/*)
 
 # Copy and package CRDs
 for file in "${files[@]}"; do
   {
-    cat hack/headers/header.yaml.txt
-    printf "\n"
-    cat "${file}"
+    cat "${file}" | sed -E "/^    controller-gen.kubebuilder.io.version.*/a \\
+    operator.solr.apache.org\\/version: ${VERSION}\\
+    argocd.argoproj.io\\/sync-options: Replace=true\\
+"
   } > "${file}.tmp" && mv "${file}.tmp" "${file}"
 done

--- a/hack/config/add_crds_annotations.sh
+++ b/hack/config/add_crds_annotations.sh
@@ -23,7 +23,7 @@ set -u
 
 echo "Add annotations to CRDs"
 
-rm -rf "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp
+rm -f "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp
 
 files=("${CONFIG_DIRECTORY:-config}"/crd/bases/*)
 

--- a/hack/config/add_crds_roles_headers.sh
+++ b/hack/config/add_crds_roles_headers.sh
@@ -23,7 +23,7 @@ set -u
 
 echo "Add headers to CRDs and Role files"
 
-rm -rf "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp "${CONFIG_DIRECTORY:-config}"/rbac/role.yaml.tmp
+rm -f "${CONFIG_DIRECTORY:-config}"/crd/bases/*.tmp "${CONFIG_DIRECTORY:-config}"/rbac/role.yaml.tmp
 
 files=("${CONFIG_DIRECTORY:-config}"/crd/bases/* "${CONFIG_DIRECTORY:-config}"/rbac/role.yaml)
 

--- a/hack/release/artifacts/create_crds.sh
+++ b/hack/release/artifacts/create_crds.sh
@@ -85,11 +85,8 @@ for filename in config/crd/bases/*.yaml; do
 done
 
 # Fetch the correct dependency Zookeeper CRD, package with other CRDS
-{
-  cat hack/headers/zookeeper-operator-header.yaml.txt;
-  printf "\n\n---\n"
-  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/v0.2.13/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml"
-} > "${ARTIFACTS_DIR}/crds/zookeeperclusters.yaml"
+./hack/zk-operator/update-crd.sh
+cp "config/dependencies/zookeeper_cluster_crd.yaml" "${ARTIFACTS_DIR}/crds/zookeeperclusters.yaml"
 
 # Package all Solr and Dependency CRDs
 {

--- a/hack/release/version/propagate_version.sh
+++ b/hack/release/version/propagate_version.sh
@@ -114,3 +114,5 @@ fi
   sed -E "s|(kubectl.+/crds/)[^/<]+|\1${VERSION}|g" | \
   sed -E "s|(helm.+--version )[^ <]+|\1${VERSION#v}|g"
 } > docs/running-the-operator.md.tmp && mv docs/running-the-operator.md.tmp docs/running-the-operator.md
+
+make manifests

--- a/hack/release/wizard/scriptutil.py
+++ b/hack/release/wizard/scriptutil.py
@@ -130,9 +130,9 @@ def find_branch_type():
 
   if branchName == b'main':
     return BranchType.unstable
-  if re.match(r'release-(\d+)', branchName.decode('UTF-8')):
+  if re.match(r'^release-(\d+)$', branchName.decode('UTF-8')):
     return BranchType.stable
-  if re.match(r'release-(\d+)\.(\d+)', branchName.decode('UTF-8')):
+  if re.match(r'^release-(\d+)\.(\d+)$', branchName.decode('UTF-8')):
     return BranchType.release
   raise Exception('Cannot run %s on feature branch' % sys.argv[0].rsplit('/', 1)[-1])
 

--- a/hack/zk-operator/update-crd.sh
+++ b/hack/zk-operator/update-crd.sh
@@ -28,7 +28,8 @@ ZK_OP_VERSION="$(cat versions.props | grep -E 'zookeeper-operator' | grep -o 'v[
   cat hack/headers/zookeeper-operator-header.yaml.txt;
   printf "\n\n---\n"
   curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/${ZK_OP_VERSION}/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml" \
-    | sed -e '/^  name: zookeeperclusters.zookeeper.pravega.io$/a \
-  annotations:\
-    argocd.argoproj.io\/sync-options: Replace=true'
+    | sed -e "/^  name: zookeeperclusters.zookeeper.pravega.io$/a \\
+  annotations:\\
+    operator.zookeeper.pravega.io\\/version: ${ZK_OP_VERSION}\\
+    argocd.argoproj.io\\/sync-options: Replace=true"
 } > config/dependencies/zookeeper_cluster_crd.yaml

--- a/hack/zk-operator/update-crd.sh
+++ b/hack/zk-operator/update-crd.sh
@@ -27,12 +27,8 @@ ZK_OP_VERSION="$(cat versions.props | grep -E 'zookeeper-operator' | grep -o 'v[
 {
   cat hack/headers/zookeeper-operator-header.yaml.txt;
   printf "\n\n---\n"
-  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/${ZK_OP_VERSION}/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml"
-} > config/dependencies/zookeeper_cluster_crd.yaml
-
-# Fetch the correct dependency Zookeeper CRD, package with other CRDS
-{
-  cat hack/headers/zookeeper-operator-header.yaml.txt;
-  printf "\n\n---\n"
-  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/${ZK_OP_VERSION}/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml"
+  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/${ZK_OP_VERSION}/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml" \
+    | sed -e '/^  name: zookeeperclusters.zookeeper.pravega.io$/a \
+  annotations:\
+    argocd.argoproj.io\/sync-options: Replace=true'
 } > config/dependencies/zookeeper_cluster_crd.yaml

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrbackups.solr.apache.org
 spec:
@@ -1272,6 +1274,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrclouds.solr.apache.org
 spec:
@@ -8332,6 +8336,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    operator.solr.apache.org/version: v0.6.0-prerelease
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: solrprometheusexporters.solr.apache.org
 spec:


### PR DESCRIPTION
Add an annotation to our CRDs that will make ArgoCD replace instead of apply.

I have edited the three base CRDs, and also the dependency ZK CRD, but that is fragile, since the ZK crd may be overwritten on next upgrade... 