### PR TITLE
Don't kill SolrCloud pods on StatefulSet creation

### DIFF
--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -322,8 +322,8 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		err = r.Get(ctx, types.NamespacedName{Name: statefulSet.Name, Namespace: statefulSet.Namespace}, foundStatefulSet)
 
 		// Set the annotation for a scheduled restart, if necessary.
-		if nextRestartAnnotation, reconcileWaitDuration, err := util.ScheduleNextRestart(instance.Spec.UpdateStrategy.RestartSchedule, foundStatefulSet.Spec.Template.Annotations); err != nil {
-			logger.Error(err, "Cannot parse restartSchedule cron", "cron", instance.Spec.UpdateStrategy.RestartSchedule)
+		if nextRestartAnnotation, reconcileWaitDuration, schedulingErr := util.ScheduleNextRestart(instance.Spec.UpdateStrategy.RestartSchedule, foundStatefulSet.Spec.Template.Annotations); schedulingErr != nil {
+			logger.Error(schedulingErr, "Cannot parse restartSchedule cron", "cron", instance.Spec.UpdateStrategy.RestartSchedule)
 		} else {
 			if nextRestartAnnotation != "" {
 				// Set the new restart time annotation
@@ -518,8 +518,6 @@ func (r *SolrCloudReconciler) reconcileCloudStatus(ctx context.Context, solrClou
 	nodeNames := make([]string, len(foundPods.Items))
 	nodeStatusMap := map[string]solrv1beta1.SolrNodeStatus{}
 
-	updateRevision := statefulSetStatus.UpdateRevision
-
 	newStatus.Replicas = statefulSetStatus.Replicas
 	newStatus.UpToDateNodes = int32(0)
 	newStatus.ReadyReplicas = int32(0)
@@ -570,7 +568,8 @@ func (r *SolrCloudReconciler) reconcileCloudStatus(ctx context.Context, solrClou
 		}
 
 		// A pod is out of date if it's revision label is not equal to the statefulSetStatus' updateRevision.
-		nodeStatus.SpecUpToDate = p.Labels["controller-revision-hash"] == updateRevision
+		updateRevision := statefulSetStatus.UpdateRevision
+		nodeStatus.SpecUpToDate = updateRevision == "" || p.Labels["controller-revision-hash"] == updateRevision
 		if nodeStatus.SpecUpToDate {
 			newStatus.UpToDateNodes += 1
 			if nodeStatus.Ready {


### PR DESCRIPTION
Fixes #431

This waits until the Operator is aware of a StatefulSet status to kill the SolrCloud pods that are out of date. Otherwise it will think all SolrCloud pods are out of date, because it doesn't have a currentRevision from the StatefulSet status.