### PR TITLE
Helm chart: fix rolebindings when watching multiple namespaces

### DIFF
--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -110,6 +110,11 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/431
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/432
+    - kind: fixed
+      description: Fixed rolebindings when watching multiple namespaces
+      links:
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/444
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.6.0-prerelease

--- a/helm/solr-operator/templates/leader_election_role_binding.yaml
+++ b/helm/solr-operator/templates/leader_election_role_binding.yaml
@@ -15,6 +15,7 @@
 
 {{- if .Values.leaderElection.enable }}
 {{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
Found that I was getting errors like:
```
error retrieving resource lock mynamespace1/88488bdc.solr.apache.org: leases.coordination.k8s.io "88488bdc.solr.apache.org" is forbidden: User "system:serviceaccount:system:solr-operator" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "mynamespace1"
```
I have deployed with the following values:
```
watchNamespaces: mynamespace1,mynamespace2
```
When I did a helm diff to switch off leader elections, I saw something like the following in the diff:
```
- # Source: solr-operator/templates/leader_election_role_binding.yaml
...
- apiVersion: rbac.authorization.k8s.io/v1
- kind: RoleBinding
- metadata:
-   name: solr-operator-leader-election-rolebinding
-   namespace: mynamespace1
- roleRef:
-   apiGroup: rbac.authorization.k8s.io
-   kind: Role
-   name: solr-operator-leader-election-role
- subjects:
-   - kind: ServiceAccount
-     name: solr-operator
-     namespace: system
- apiVersion: rbac.authorization.k8s.io/v1
- kind: RoleBinding
- metadata:
-   name: solr-operator-leader-election-rolebinding
-   namespace: mynamespace2
- roleRef:
-   apiGroup: rbac.authorization.k8s.io
-   kind: Role
-   name: solr-operator-leader-election-role
- subjects:
-   - kind: ServiceAccount
-     name: solr-operator
-     namespace: system
```
Which looks right, except for the missing `---`, which is what this PR adds.

My workaround is to run with:
```yaml
leaderElection:
  enable: false
replicaCount: 1
```
(1 is the default number of replicas anyway, but I imagine strange things happen with multiple replicas and no leader election, so important it is set to 1)