### PR TITLE
Remove remaining 'backupRestoreOptions' references

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -363,8 +363,6 @@ type SolrBackupRepository struct {
 	S3 *S3Repository `json:"s3,omitempty"`
 
 	// Allows specification of a "repository" for Solr to use when backing up data "locally".
-	// Repositories defined here are considered "managed" and can take advantage of special operator features, such as
-	// post-backup compression.
 	//+optional
 	Volume *VolumeRepository `json:"volume,omitempty"`
 }

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -209,7 +209,7 @@ spec:
                       - region
                       type: object
                     volume:
-                      description: Allows specification of a "repository" for Solr to use when backing up data "locally". Repositories defined here are considered "managed" and can take advantage of special operator features, such as post-backup compression.
+                      description: Allows specification of a "repository" for Solr to use when backing up data "locally".
                       properties:
                         directory:
                           description: Select a custom directory name to mount the backup/restore data in the given volume. If not specified, then the name of the solrcloud will be used by default.

--- a/docs/solr-cloud/solr-cloud-crd.md
+++ b/docs/solr-cloud/solr-cloud-crd.md
@@ -70,13 +70,6 @@ These options can be found in `SolrCloud.spec.dataStorage`
   If both are specified then the `hostPath` volume source will take precedence.
   - **`emptyDir`** - An [`emptyDir` volume source](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) that describes the desired emptyDir volume to use in each SolrCloud pod to store data.
   - **`hostPath`** - A [`hostPath` volume source](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) that describes the desired hostPath volume to use in each SolrCloud pod to store data.
-    
-- **`backupRestoreOptions`** (Required for integration with [`SolrBackups`](../solr-backup/README.md))
-  - **`volume`** - This is a [volume source](https://kubernetes.io/docs/concepts/storage/volumes/), that supports `ReadWriteMany` access.
-  This is critical because this single volume will be loaded into all pods at the same path.
-  - **`directory`** - A custom directory to store backup/restore data, within the volume described above.
-  This is optional, and defaults to the name of the SolrCloud.
-  Only use this option when you require restoring the same backup to multiple SolrClouds.
 
 ## Update Strategy
 _Since v0.2.7_

--- a/example/test_backup_gcs.yaml
+++ b/example/test_backup_gcs.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assumes a 'solrcloud' whose 'backupRestoreOptions' match the "Multiple Backup
+# Assumes a 'solrcloud' whose 'backupRepositories' match the "Multiple Backup
 # Repositories" solrcloud example ('test_solrcloud_backuprepos.yaml')
 apiVersion: solr.apache.org/v1beta1
 kind: SolrBackup

--- a/example/test_backup_volume.yaml
+++ b/example/test_backup_volume.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assumes a 'solrcloud' whose 'backupRestoreOptions' match the "Multiple Backup Repositories" solrcloud example ('test_solrcloud_backuprepos.yaml')
+# Assumes a 'solrcloud' whose 'backupRepositories' match the "Multiple Backup Repositories" solrcloud example ('test_solrcloud_backuprepos.yaml')
 apiVersion: solr.apache.org/v1beta1
 kind: SolrBackup
 metadata:

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -441,7 +441,7 @@ spec:
                       - region
                       type: object
                     volume:
-                      description: Allows specification of a "repository" for Solr to use when backing up data "locally". Repositories defined here are considered "managed" and can take advantage of special operator features, such as post-backup compression.
+                      description: Allows specification of a "repository" for Solr to use when backing up data "locally".
                       properties:
                         directory:
                           description: Select a custom directory name to mount the backup/restore data in the given volume. If not specified, then the name of the solrcloud will be used by default.

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -125,8 +125,6 @@ See the [documentation](https://apache.github.io/solr-operator/docs/solr-cloud/s
 | dataStorage.persistent.pvc.annotations | map[string]string | | Set the annotations for your Solr data PVCs |
 | dataStorage.persistent.pvc.labels | map[string]string | | Set the labels for your Solr data PVCs |
 | dataStorage.persistent.pvc.storageClassName | string | | Override the default storageClass for your Solr data PVCs |
-| dataStorage.backupRestoreOptions.volume | object | | **DEPRECATED: Use a Volume Repo in `backupRepositories` instead. This option will be removed in `v0.6.0`.** A read-write-many volume that can be attached to all Solr pods, for the purpose of storing backup data. This is required when using the SolrBackup CRD. |
-| dataStorage.backupRestoreOptions.directory | string | | **DEPRECATED: Use a Volume Repo in `backupRepositories` instead. This option will be removed in `v0.6.0`.** Override the default backup-restore volume location in the Solr container |
 
 ### Addressability Options
 

--- a/helm/solr/templates/solrcloud.yaml
+++ b/helm/solr/templates/solrcloud.yaml
@@ -146,10 +146,6 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if .Values.dataStorage.backupRestoreOptions }}
-    backupRestoreOptions:
-      {{- toYaml .Values.dataStorage.backupRestoreOptions | nindent 6 }}
-    {{- end }}
   {{- end }}
 
   {{- if .Values.solrOptions.solrModules }}

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -130,13 +130,6 @@ dataStorage:
       annotations: {}
       storageClassName: ""
 
-  # BackupRestoreOptions is required when using this cloud with the SolrBackup CRD.
-  # DEPRECATED: Please use backupRepositories instead.
-  # TODO: Remove in v0.6.0
-  backupRestoreOptions: {}
-    # volume: {}
-    # directory: ""
-
 # A list of BackupRepositories to connect your SolrCloud to
 # See either for more information:
 # - https://apache.github.io/solr-operator/docs/solr-backup


### PR DESCRIPTION
The CRD option had been removed from 0.6.0 by a prior commit but a few
dangling references still remainined.  This cleans those up to help
clarify the docs around backup functionality.