### PR TITLE
Option to merge the JVM truststore with user-supplied truststore

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -1523,6 +1523,14 @@ type SolrTLSOptions struct {
 	// This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
 	// +optional
 	MountedTLSDir *MountedTLSDirectory `json:"mountedTLSDir,omitempty"`
+
+	// Path on the Solr image to your JVM's truststore to merge with an external truststore.
+	// If supplied, Solr will be configured to use the merged truststore.
+	// The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts
+	MergeJavaTruststore string `json:"mergeJavaTrustStore,omitempty"`
+
+	// Password for the Java truststore to merge; defaults to "changeit"
+	MergeJavaTruststorePass string `json:"mergeJavaTrustStorePass,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=Basic

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -4926,6 +4926,12 @@ spec:
                     required:
                     - key
                     type: object
+                  mergeJavaTrustStore:
+                    description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                    type: string
+                  mergeJavaTrustStorePass:
+                    description: Password for the Java truststore to merge; defaults to "changeit"
+                    type: string
                   mountedTLSDir:
                     description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                     properties:
@@ -5087,6 +5093,12 @@ spec:
                     required:
                     - key
                     type: object
+                  mergeJavaTrustStore:
+                    description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                    type: string
+                  mergeJavaTrustStorePass:
+                    description: Password for the Java truststore to merge; defaults to "changeit"
+                    type: string
                   mountedTLSDir:
                     description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                     properties:

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -3688,6 +3688,12 @@ spec:
                         required:
                         - key
                         type: object
+                      mergeJavaTrustStore:
+                        description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                        type: string
+                      mergeJavaTrustStorePass:
+                        description: Password for the Java truststore to merge; defaults to "changeit"
+                        type: string
                       mountedTLSDir:
                         description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                         properties:

--- a/controllers/solrprometheusexporter_controller_tls_test.go
+++ b/controllers/solrprometheusexporter_controller_tls_test.go
@@ -228,6 +228,38 @@ var _ = FDescribe("SolrPrometheusExporter controller - TLS", func() {
 		})
 	})
 
+	FContext("TLS Secret - Merge TrustStore Only", func() {
+		tlsSecretName := "tls-cert-secret-from-user"
+		BeforeEach(func() {
+			solrPrometheusExporter.Spec = solrv1beta1.SolrPrometheusExporterSpec{
+				SolrReference: solrv1beta1.SolrReference{
+					Cloud: &solrv1beta1.SolrCloudReference{
+						ZookeeperConnectionInfo: &solrv1beta1.ZookeeperConnectionInfo{
+							InternalConnectionString: "host:2181",
+							ChRoot:                   "/this/path",
+						},
+					},
+					SolrTLS: &solrv1beta1.SolrTLSOptions{
+						TrustStorePasswordSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: tlsSecretName},
+							Key:                  "keystore-passwords-are-important",
+						},
+						TrustStoreSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: tlsSecretName},
+							Key:                  util.DefaultPkcs12TruststoreFile,
+						},
+						RestartOnTLSSecretUpdate: false,
+						MergeJavaTruststore:      util.DefaultJvmTruststore,
+					},
+				},
+			}
+		})
+		FIt("has the correct resources", func() {
+			By("testing the SolrPrometheusExporter Deployment")
+			testReconcileWithTruststoreOnly(ctx, solrPrometheusExporter, tlsSecretName)
+		})
+	})
+
 	FContext("TLS Secret - TrustStore Only - Restart on Secret Update", func() {
 		tlsSecretName := "tls-cert-secret-from-user"
 		BeforeEach(func() {

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -5158,6 +5158,12 @@ spec:
                     required:
                     - key
                     type: object
+                  mergeJavaTrustStore:
+                    description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                    type: string
+                  mergeJavaTrustStorePass:
+                    description: Password for the Java truststore to merge; defaults to "changeit"
+                    type: string
                   mountedTLSDir:
                     description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                     properties:
@@ -5319,6 +5325,12 @@ spec:
                     required:
                     - key
                     type: object
+                  mergeJavaTrustStore:
+                    description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                    type: string
+                  mergeJavaTrustStorePass:
+                    description: Password for the Java truststore to merge; defaults to "changeit"
+                    type: string
                   mountedTLSDir:
                     description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                     properties:
@@ -10119,6 +10131,12 @@ spec:
                         required:
                         - key
                         type: object
+                      mergeJavaTrustStore:
+                        description: 'Path on the Solr image to your JVM''s truststore to merge with an external truststore. If supplied, Solr will be configured to use the merged truststore. The truststore for the JVM in the default Solr image is: $JAVA_HOME/lib/security/cacerts'
+                        type: string
+                      mergeJavaTrustStorePass:
+                        description: Password for the Java truststore to merge; defaults to "changeit"
+                        type: string
                       mountedTLSDir:
                         description: Used to specify a path where the keystore, truststore, and password files for the TLS certificate are mounted by an external agent or CSI driver. This option is typically used with `spec.updateStrategy.restartSchedule` to restart Solr pods before the mounted TLS cert expires.
                         properties:


### PR DESCRIPTION
Fixes #390 ~ by allowing the JVM cacerts to get merged in with the user-supplied truststore (Let's Encrypt's CA is in the cacerts for modern JVM)

Users can now configure the TLS options to merge the JVM's truststore with the truststore for their certs using:
```
spec:
  ...
  solrTLS:
    ...
    trustStoreSecret:
      name: dev-selfsigned-cert-tls
      key: truststore.p12
    mergeJavaTrustStore: "$JAVA_HOME/lib/security/cacerts"
```
The path given in `mergeJavaTrustStore` option must exist on the Solr docker image! Thus, if user's customize their Solr image, this path may be different.

Behind the scenes, this creates an additional `initContainer` that merges the two truststores together and then points the env var to the "merged" truststore:

For server TLS:
```
- name: SOLR_SSL_TRUST_STORE
   value: /var/solr/tls-merged/truststore.p12
``

By pointing `SOLR_SSL_TRUST_STORE` env var at the merged truststore, we're ensured that all the other initContainers and liveness probes continue to work (as they just use the env var to resolve this path).

Added a few simple unit tests and tested manually in my cluster. 

For Prom exporter, the config would be:
```
spec:
  solrReference:
    ...
    solrTLS:
      ...
      mergeJavaTrustStore: "$JAVA_HOME/lib/security/cacerts"
```

Which results in the exporter container getting configed with env var:
```
- name: SOLR_SSL_CLIENT_TRUST_STORE
   value: /var/solr/tls-merged/truststore.p12
```
