### PR TITLE
Release 0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,10 @@ check-git: ## Check to make sure the repo does not have uncommitted code
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate ## Run the unit tests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+	# Kubebuilder-tools doesn't have a darwin+arm (i.e. Apple Silicon) distribution but the amd one works fine for our purposes
+	if [[ "${GOOS}" == "darwin" && "${ARCH}" == "arm64" ]]; then export GOARCH=amd64; fi; \
+	mkdir -p ${ENVTEST_ASSETS_DIR}; \
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh; \
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); GINKGO_EDITOR_INTEGRATION=true go test ./... -coverprofile cover.out
 
 ##@ Helm

--- a/api/v1beta1/solrbackup_types.go
+++ b/api/v1beta1/solrbackup_types.go
@@ -121,7 +121,7 @@ type IndividualSolrBackupStatus struct {
 	// +optional
 	CollectionBackupStatuses []CollectionBackupStatus `json:"collectionBackupStatuses,omitempty"`
 
-	// Version of the Solr being backed up
+	// The time that this backup was finished
 	// +optional
 	FinishTime *metav1.Time `json:"finishTimestamp,omitempty"`
 

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -844,8 +844,7 @@ type ZookeeperSpec struct {
 	// +optional
 	ReadOnlyACL *ZookeeperACL `json:"readOnlyAcl,omitempty"`
 
-	// ZooKeeper ACL to use when connecting with ZK for reading operations.
-	// This ACL should have READ permission in the given chRoot.
+	// Additional Zookeeper Configuration settings
 	// +optional
 	Config ZookeeperConfig `json:"config,omitempty"`
 }
@@ -1416,6 +1415,16 @@ func (sc *SolrCloud) AdvertisedNodeHost(nodeName string) string {
 
 func (sc *SolrCloud) UsesPersistentStorage() bool {
 	return sc.Spec.StorageOptions.PersistentStorage != nil
+}
+
+func (sc *SolrCloud) DataVolumeName() string {
+	// Set the default name of the pvc
+	if sc.Spec.StorageOptions.PersistentStorage != nil &&
+		sc.Spec.StorageOptions.PersistentStorage.PersistentVolumeClaimTemplate.ObjectMeta.Name != "" {
+		return sc.Spec.StorageOptions.PersistentStorage.PersistentVolumeClaimTemplate.ObjectMeta.Name
+	} else {
+		return "data"
+	}
 }
 
 func (sc *SolrCloud) SharedLabels() map[string]string {

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -153,7 +153,7 @@ spec:
                   type: object
                 type: array
               finishTimestamp:
-                description: Version of the Solr being backed up
+                description: The time that this backup was finished
                 format: date-time
                 type: string
               finished:
@@ -200,7 +200,7 @@ spec:
                         type: object
                       type: array
                     finishTimestamp:
-                      description: Version of the Solr being backed up
+                      description: The time that this backup was finished
                       format: date-time
                       type: string
                     finished:

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -5267,7 +5267,7 @@ spec:
                         description: The ChRoot to connect solr at
                         type: string
                       config:
-                        description: ZooKeeper ACL to use when connecting with ZK for reading operations. This ACL should have READ permission in the given chRoot.
+                        description: Additional Zookeeper Configuration settings
                         properties:
                           additionalConfig:
                             additionalProperties:

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -45,7 +45,6 @@ const (
 	SolrCloudPVCTechnology           = "solr-cloud"
 	SolrPVCStorageLabel              = "solr.apache.org/storage"
 	SolrCloudPVCDataStorage          = "data"
-	SolrDataVolumeName               = "data"
 	SolrPVCInstanceLabel             = "solr.apache.org/instance"
 	SolrXmlMd5Annotation             = "solr.apache.org/solrXmlMd5"
 	SolrXmlFile                      = "solr.xml"
@@ -143,18 +142,14 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 		},
 	}
 
-	solrDataVolumeName := SolrDataVolumeName
+	solrDataVolumeName := solrCloud.DataVolumeName()
 
 	var pvcs []corev1.PersistentVolumeClaim
 	if solrCloud.UsesPersistentStorage() {
 		pvc := solrCloud.Spec.StorageOptions.PersistentStorage.PersistentVolumeClaimTemplate.DeepCopy()
 
 		// Set the default name of the pvc
-		if pvc.ObjectMeta.Name == "" {
-			pvc.ObjectMeta.Name = solrDataVolumeName
-		} else {
-			solrDataVolumeName = pvc.ObjectMeta.Name
-		}
+		pvc.ObjectMeta.Name = solrDataVolumeName
 
 		// Set some defaults in the PVC Spec
 		if len(pvc.Spec.AccessModes) == 0 {

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -41,7 +41,7 @@ This tutorial shows how to setup Solr under Kubernetes on your local mac. The pl
 	https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 # Install Docker Desktop for Mac (use edge version to get latest k8s)
-brew cask install docker-edge
+brew install --cask docker
 
 # Enable Kubernetes in Docker Settings, or run the command below:
 sed -i -e 's/"kubernetesEnabled" : false/"kubernetesEnabled" : true/g' \

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -90,9 +90,9 @@ This will install the [Zookeeper Operator](https://github.com/pravega/zookeeper-
 
 ```bash
 # Install the Solr & Zookeeper CRDs
-$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0-prerelease/all-with-dependencies.yaml
+$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
 # Install the Solr operator and Zookeeper Operator
-$ helm install solr-operator apache-solr/solr-operator --version 0.6.0-prerelease
+$ helm install solr-operator apache-solr/solr-operator --version 0.6.0
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._
@@ -123,7 +123,7 @@ To start a Solr Cloud cluster, we will create a yaml that will tell the Solr Ope
 
 ```bash
 # Create a 3-node cluster v8.3 with 300m Heap each:
-helm install example-solr apache-solr/solr --version 0.6.0-prerelease \
+helm install example-solr apache-solr/solr --version 0.6.0 \
   --set image.tag=8.3 \
   --set solrOptions.javaMemory="-Xms300m -Xmx300m" \
   --set addressability.external.method=Ingress \
@@ -211,7 +211,7 @@ So we wish to upgrade to a newer Solr version:
 curl -s http://default-example-solrcloud.ing.local.domain/solr/admin/info/system | grep solr-i
 
 # Update the solrCloud configuration with the new version, keeping all previous settings and the number of nodes set by the autoscaler.
-helm upgrade example-solr apache-solr/solr --version 0.6.0-prerelease \
+helm upgrade example-solr apache-solr/solr --version 0.6.0 \
   --reuse-values \
   --set image.tag=8.7
 

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -90,9 +90,9 @@ This will install the [Zookeeper Operator](https://github.com/pravega/zookeeper-
 
 ```bash
 # Install the Solr & Zookeeper CRDs
-$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
+$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.1-prerelease/all-with-dependencies.yaml
 # Install the Solr operator and Zookeeper Operator
-$ helm install solr-operator apache-solr/solr-operator --version 0.6.0
+$ helm install solr-operator apache-solr/solr-operator --version 0.6.1-prerelease
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._
@@ -123,7 +123,7 @@ To start a Solr Cloud cluster, we will create a yaml that will tell the Solr Ope
 
 ```bash
 # Create a 3-node cluster v8.3 with 300m Heap each:
-helm install example-solr apache-solr/solr --version 0.6.0 \
+helm install example-solr apache-solr/solr --version 0.6.1-prerelease \
   --set image.tag=8.3 \
   --set solrOptions.javaMemory="-Xms300m -Xmx300m" \
   --set addressability.external.method=Ingress \
@@ -211,7 +211,7 @@ So we wish to upgrade to a newer Solr version:
 curl -s http://default-example-solrcloud.ing.local.domain/solr/admin/info/system | grep solr-i
 
 # Update the solrCloud configuration with the new version, keeping all previous settings and the number of nodes set by the autoscaler.
-helm upgrade example-solr apache-solr/solr --version 0.6.0 \
+helm upgrade example-solr apache-solr/solr --version 0.6.1-prerelease \
   --reuse-values \
   --set image.tag=8.7
 

--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -38,8 +38,8 @@ Next, install the Solr Operator chart. Note this is using Helm v3, use the offic
 This will install the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) by default.
 
 ```bash
-$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
-$ helm install solr-operator apache-solr/solr-operator --version 0.6.0
+$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.1-prerelease/all-with-dependencies.yaml
+$ helm install solr-operator apache-solr/solr-operator --version 0.6.1-prerelease
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._

--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -38,8 +38,8 @@ Next, install the Solr Operator chart. Note this is using Helm v3, use the offic
 This will install the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) by default.
 
 ```bash
-$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0-prerelease/all-with-dependencies.yaml
-$ helm install solr-operator apache-solr/solr-operator --version 0.6.0-prerelease
+$ kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
+$ helm install solr-operator apache-solr/solr-operator --version 0.6.0
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._

--- a/docs/solr-backup/README.md
+++ b/docs/solr-backup/README.md
@@ -109,7 +109,7 @@ test   example   123m      true       false                     161m
 _Since v0.5.0_
 
 The Solr Operator enables taking recurring updates, at a set interval.
-Note that this feature requires a SolrCloud running Solr `8.9.0` or older, because it relies on `Incremental` backups.
+Note that this feature requires a SolrCloud running Solr >= `8.9.0`, because it relies on `Incremental` backups.
 
 By default the Solr Operator will save a maximum of **5** backups at a time, however users can override this using `SolrBackup.spec.recurrence.maxSaved`.
 When using `recurrence`, users must provide a Cron-style `schedule` for the interval at which backups should be taken.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -99,8 +99,8 @@ If you are using the Solr Helm chart to deploy the Zookeeper operator, then you 
 
 ```bash
 # Just replace the Solr CRDs and all CRDs it might depend on (e.g. ZookeeperCluster)
-kubectl replace -f "http://solr.apache.org/operator/downloads/crds/v0.6.0-prerelease/all-with-dependencies.yaml"
-helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0-prerelease
+kubectl replace -f "http://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml"
+helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -99,8 +99,8 @@ If you are using the Solr Helm chart to deploy the Zookeeper operator, then you 
 
 ```bash
 # Just replace the Solr CRDs and all CRDs it might depend on (e.g. ZookeeperCluster)
-kubectl replace -f "http://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml"
-helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0
+kubectl replace -f "http://solr.apache.org/operator/downloads/crds/v0.6.1-prerelease/all-with-dependencies.yaml"
+helm upgrade solr-operator apache-solr/solr-operator --version 0.6.1-prerelease
 ```
 
 _Note that the Helm chart version does not contain a `v` prefix, which the downloads version does. The Helm chart version is the only part of the Solr Operator release that does not use the `v` prefix._

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -15,8 +15,8 @@
 apiVersion: v2
 name: solr-operator
 description: The Solr Operator enables easy management of Solr resources within Kubernetes.
-version: 0.6.0
-appVersion: v0.6.0
+version: 0.6.1-prerelease
+appVersion: v0.6.1-prerelease
 kubeVersion: ">= 1.19.0-0"
 home: https://solr.apache.org/operator
 sources:
@@ -41,142 +41,31 @@ dependencies:
 annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: Full Lifecycle
-  artifacthub.io/prerelease: "false"
+  artifacthub.io/prerelease: "true"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr
   artifacthub.io/links: |
     - name: "Tutorials"
       url: https://solr.apache.org/operator/resources#tutorials
   artifacthub.io/signKey: |
-    fingerprint: E05FDF113D89E7FB4A2DF4B2684D544160392455
+    fingerprint: <fingerprint>
     url: https://dist.apache.org/repos/dist/release/solr/KEYS
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade the default Solr version to 8.11
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/387
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/388
-    - kind: changed
-      description: The required Zookeeper Operator version has been upgraded to v0.2.14
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/443
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/449
-        - name: Zookeeper Operator v0.2.14 Release
-          url: https://github.com/pravega/zookeeper-operator/releases/tag/v0.2.14
-    - kind: changed
-      description: Loosen requirement on GCS backup credential/secret. Can now be omitted if using GKE's Workload Identity.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/391
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/394
-    - kind: changed
-      description: The "addressability.external.additionalDomains" option has been renamed to "addressability.external.additionalDomainNames". See the upgrade notes for more information.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/412
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/416
     - kind: added
-      description: You can now do a managed update of Solr while using ephemeral data. The operator will manage data migration during the rolling update for you.
+      description: Addition 1
       links:
         - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/365
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/375
-    - kind: removed
-      description: Options deprecated in v0.5.0 have been removed. See the upgrade notes for more information.
-      links:
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/418
-    - kind: fixed
-      description: Fixed issue with StatefulSet volumeMounts for PVCs with custom names.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/438
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/439
-    - kind: fixed
-      description: SolrCloud pods are no longer deleted right after a SolrCloud is created.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/431
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/432
-    - kind: fixed
-      description: Fixed rolebindings when watching multiple namespaces
-      links:
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/444
-    - kind: fixed
-      description: SolrClouds now support a ZookeeperConnection address without the port (uses 2181 by default). The operator will also log whenever the statefulSet is skipped because of the zkConnectionString.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/428
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/429
-    - kind: fixed
-      description: SolrCloud.Status now shows correct version when using an image repo that contains a colon
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/445
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/450
-    - kind: added
-      description: SolrCloud and SolrPrometheusExporter Services now have the appropriate (http or https) appProtocol set. This fixes integration with Istio.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/427
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/453
+          url: https://github.com/issue-url
     - kind: changed
-      description: SolrPrometheusExporters now default to using the references SolrCloud image if none is provided. Note, the entire PrometheusExporter image specification must be empty for it to use the SolrCloud image. This does not effect existing resources, only newly created resources.
+      description: Change 2
       links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/386
         - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/454
-    - kind: added
-      description: SolrCloud default initContainer(s) can now have their resources customized via `podOptions.defaultInitContainerResources`. These initContainers now include default resources.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/448
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/451
-    - kind: changed
-      description: SolrBackup.Status' 'Next Scheduled' is now updated on changes to the backup schedule.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/376
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/455
-    - kind: changed
-      description: SolrClouds can now use the Ingress controller's default TLS Secret when terminating TLS at the Ingress. The old `ingressTLSTerminationSecret` option is now deprecated. Refer the upgrade notes for more information.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/437
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/452
-        - name: Upgrade Notes
-          url: https://apache.github.io/solr-operator/docs/upgrade-notes.html#v060
-        - name: Solr Addressability Docs
-          url: https://apache.github.io/solr-operator/docs/solr-cloud/solr-cloud-crd.html#addressability
-    - kind: added
-      description: SolrCloud now accepts a `solrZkOpts` option for specifying any Java system properties needed to connect to ZooKeeper.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/435
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/456
+          url: https://github.com/pr-url
   artifacthub.io/images: |
     - name: solr-operator
-      image: apache/solr-operator:v0.6.0
+      image: apache/solr-operator:v0.6.1-prerelease
   artifacthub.io/crds: |
     - kind: SolrCloud
       version: v1beta1

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -53,16 +53,13 @@ annotations:
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
-    - kind: added
-      description: Addition 1
+    - kind: fixed
+      description: Fix bug with named PVCs
       links:
         - name: Github Issue
-          url: https://github.com/issue-url
-    - kind: changed
-      description: Change 2
-      links:
+          url: https://github.com/apache/solr-operator/issues/479
         - name: Github PR
-          url: https://github.com/pr-url
+          url: https://github.com/apache/solr-operator/pull/481
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.6.1-prerelease

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -12,12 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v2
 name: solr-operator
 description: The Solr Operator enables easy management of Solr resources within Kubernetes.
-version: 0.6.0-prerelease
-appVersion: v0.6.0-prerelease
+version: 0.6.0
+appVersion: v0.6.0
 kubeVersion: ">= 1.19.0-0"
 home: https://solr.apache.org/operator
 sources:
@@ -42,14 +41,14 @@ dependencies:
 annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: Full Lifecycle
-  artifacthub.io/prerelease: "true"
+  artifacthub.io/prerelease: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr
   artifacthub.io/links: |
     - name: "Tutorials"
       url: https://solr.apache.org/operator/resources#tutorials
   artifacthub.io/signKey: |
-    fingerprint: <fingerprint>
+    fingerprint: E05FDF113D89E7FB4A2DF4B2684D544160392455
     url: https://dist.apache.org/repos/dist/release/solr/KEYS
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
@@ -177,7 +176,7 @@ annotations:
           url: https://github.com/apache/solr-operator/pull/456
   artifacthub.io/images: |
     - name: solr-operator
-      image: apache/solr-operator:v0.6.0-prerelease
+      image: apache/solr-operator:v0.6.0
   artifacthub.io/crds: |
     - kind: SolrCloud
       version: v1beta1

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -43,8 +43,8 @@ helm repo add apache-solr https://solr.apache.org/charts
 To install the Solr Operator for the first time in your cluster, you can use the latest version or a specific version, run with the following commands:
 
 ```bash
-kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0-prerelease/all-with-dependencies.yaml
-helm install solr-operator apache-solr/solr-operator --version 0.6.0-prerelease
+kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
+helm install solr-operator apache-solr/solr-operator --version 0.6.0
 ```
 
 The command deploys the solr-operator on the Kubernetes cluster with the default configuration.
@@ -57,8 +57,8 @@ _Note that the Helm chart version does not contain a `v` prefix, which the downl
 If you are upgrading your Solr Operator deployment, you should always use a specific version of the chart and pre-install the Solr CRDS:
 
 ```bash
-kubectl replace -f https://solr.apache.org/operator/downloads/crds/v0.6.0-prerelease/all-with-dependencies.yaml
-helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0-prerelease
+kubectl replace -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
+helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0
 ```
 
 #### Namespaces
@@ -172,7 +172,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"apache/solr-operator"` | The repository of the Solr Operator image |
-| image.tag | string | `"v0.6.0-prerelease"` | The tag/version of the Solr Operator to run |
+| image.tag | string | `"v0.6.0"` | The tag/version of the Solr Operator to run |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | fullnameOverride | string | `""` | A custom name for the Solr Operator Deployment |
 | nameOverride | string | `""` |  |

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -43,8 +43,8 @@ helm repo add apache-solr https://solr.apache.org/charts
 To install the Solr Operator for the first time in your cluster, you can use the latest version or a specific version, run with the following commands:
 
 ```bash
-kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
-helm install solr-operator apache-solr/solr-operator --version 0.6.0
+kubectl create -f https://solr.apache.org/operator/downloads/crds/v0.6.1-prerelease/all-with-dependencies.yaml
+helm install solr-operator apache-solr/solr-operator --version 0.6.1-prerelease
 ```
 
 The command deploys the solr-operator on the Kubernetes cluster with the default configuration.
@@ -57,8 +57,8 @@ _Note that the Helm chart version does not contain a `v` prefix, which the downl
 If you are upgrading your Solr Operator deployment, you should always use a specific version of the chart and pre-install the Solr CRDS:
 
 ```bash
-kubectl replace -f https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
-helm upgrade solr-operator apache-solr/solr-operator --version 0.6.0
+kubectl replace -f https://solr.apache.org/operator/downloads/crds/v0.6.1-prerelease/all-with-dependencies.yaml
+helm upgrade solr-operator apache-solr/solr-operator --version 0.6.1-prerelease
 ```
 
 #### Namespaces
@@ -172,7 +172,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"apache/solr-operator"` | The repository of the Solr Operator image |
-| image.tag | string | `"v0.6.0"` | The tag/version of the Solr Operator to run |
+| image.tag | string | `"v0.6.1-prerelease"` | The tag/version of the Solr Operator to run |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | fullnameOverride | string | `""` | A custom name for the Solr Operator Deployment |
 | nameOverride | string | `""` |  |

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -250,7 +250,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -6449,7 +6449,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0-prerelease
+    operator.solr.apache.org/version: v0.6.0
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -250,7 +250,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -6449,7 +6449,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.6.0
+    operator.solr.apache.org/version: v0.6.1-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -153,7 +153,7 @@ spec:
                   type: object
                 type: array
               finishTimestamp:
-                description: Version of the Solr being backed up
+                description: The time that this backup was finished
                 format: date-time
                 type: string
               finished:
@@ -200,7 +200,7 @@ spec:
                         type: object
                       type: array
                     finishTimestamp:
-                      description: Version of the Solr being backed up
+                      description: The time that this backup was finished
                       format: date-time
                       type: string
                     finished:
@@ -5499,7 +5499,7 @@ spec:
                         description: The ChRoot to connect solr at
                         type: string
                       config:
-                        description: ZooKeeper ACL to use when connecting with ZK for reading operations. This ACL should have READ permission in the given chRoot.
+                        description: Additional Zookeeper Configuration settings
                         properties:
                           additionalConfig:
                             additionalProperties:

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -21,7 +21,7 @@ replicaCount: 1
 
 image:
   repository: apache/solr-operator
-  tag: v0.6.0
+  tag: v0.6.1-prerelease
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -21,7 +21,7 @@ replicaCount: 1
 
 image:
   repository: apache/solr-operator
-  tag: v0.6.0-prerelease
+  tag: v0.6.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -12,11 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v2
 name: solr
 description: A SolrCloud cluser running on Kubernetes via the Solr Operator
-version: 0.6.0-prerelease
+version: 0.6.0
 appVersion: 8.11.1
 kubeVersion: ">= 1.19.0-0"
 home: https://solr.apache.org
@@ -36,7 +35,7 @@ maintainers:
 icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
 annotations:
   artifacthub.io/operator: "false"
-  artifacthub.io/prerelease: "true"
+  artifacthub.io/prerelease: "false"
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
@@ -76,5 +75,5 @@ annotations:
       image: solr:8.11
       whitelisted: true
   artifacthub.io/signKey: |
-    fingerprint: <fingerprint>
+    fingerprint: E05FDF113D89E7FB4A2DF4B2684D544160392455
     url: https://dist.apache.org/repos/dist/release/solr/KEYS

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: solr
 description: A SolrCloud cluser running on Kubernetes via the Solr Operator
-version: 0.6.0
+version: 0.6.1-prerelease
 appVersion: 8.11.1
 kubeVersion: ">= 1.19.0-0"
 home: https://solr.apache.org
@@ -35,29 +35,20 @@ maintainers:
 icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
 annotations:
   artifacthub.io/operator: "false"
-  artifacthub.io/prerelease: "false"
+  artifacthub.io/prerelease: "true"
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade the default Solr version to 8.11
+    - kind: added
+      description: Addition 1
       links:
         - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/387
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/388
+          url: https://github.com/issue-url
     - kind: changed
-      description: The "addressability.external.additionalDomains" option has been renamed to "addressability.external.additionalDomainNames". See the upgrade notes for more information.
-      links:
-        - name: Github Issue
-          url: https://github.com/apache/solr-operator/issues/412
-        - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/416
-    - kind: removed
-      description: The deprecated "dataStorage.backupRestoreOptions" field has been removed.
+      description: Change 2
       links:
         - name: Github PR
-          url: https://github.com/apache/solr-operator/pull/418
+          url: https://github.com/pr-url
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
@@ -75,5 +66,5 @@ annotations:
       image: solr:8.11
       whitelisted: true
   artifacthub.io/signKey: |
-    fingerprint: E05FDF113D89E7FB4A2DF4B2684D544160392455
+    fingerprint: <fingerprint>
     url: https://dist.apache.org/repos/dist/release/solr/KEYS

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -177,13 +177,12 @@ Currently the Zookeeper Operator does not support ACLs, so do not use the provid
 | zk.provided.zookeeperPodPolicy.labels | map[string]string |  | List of additional labels to add to the Zookeeper pod |
 | zk.provided.zookeeperPodPolicy.annotations | map[string]string |  | List of additional annotations to add to the Zookeeper pod |
 | zk.provided.zookeeperPodPolicy.serviceAccountName | string |  | Optional serviceAccount to run the ZK Pod under |
-| zk.provided.zookeeperPodPolicy.affinity | string |  | PullSecret for the ZooKeeper image |
 | zk.provided.zookeeperPodPolicy.resources.limits | map[string]string |  | Provide Resource limits for the ZooKeeper containers |
 | zk.provided.zookeeperPodPolicy.resources.requests | map[string]string |  | Provide Resource requests for the ZooKeeper containers |
 | zk.provided.zookeeperPodPolicy.nodeSelector | map[string]string |  | Add a node selector for the ZooKeeper pod, to specify where it can be scheduled |
 | zk.provided.zookeeperPodPolicy.affinity | object |  | Add Kubernetes affinity information for the ZooKeeper pod |
 | zk.provided.zookeeperPodPolicy.tolerations | []object |  | Specify a list of Kubernetes tolerations for the ZooKeeper pod |
-| zk.provided.zookeeperPodPolicy.envVars | []object |  | List of additional environment variables for the ZooKeeper container |
+| zk.provided.zookeeperPodPolicy.env | []object |  | List of additional environment variables for the ZooKeeper container |
 | zk.provided.zookeeperPodPolicy.securityContext | object |  | Security context for the entire ZooKeeper pod. More information can be found in the [Kubernetes docs](More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context). |
 | zk.provided.zookeeperPodPolicy.terminationGracePeriodSeconds | int | `30` | The amount of time that Kubernetes will give for a zookeeper pod instance to shutdown normally. |
 | zk.provided.zookeeperPodPolicy.imagePullSecrets | []object |  | List of image pull secrets to inject into the Zookeeper pod. |

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -38,7 +38,7 @@ There may be breaking changes between the version you are using and the version 
 To install the Solr Operator for the first time in your cluster, you can use the latest version or a specific version, run with the following commands:
 
 ```bash
-helm install example apache-solr/solr --version 0.6.0-prerelease --set image.tag=8.8
+helm install example apache-solr/solr --version 0.6.0 --set image.tag=8.8
 ```
 
 The command deploys a SolrCloud object on the Kubernetes cluster with the default configuration.
@@ -52,7 +52,7 @@ _Note that the Helm chart version does not contain a `v` prefix, which the Solr 
 If you are upgrading your SolrCloud deployment, you should always use a specific version of the chart and upgrade **after [upgrading the Solr Operator](https://artifacthub.io/packages/helm/apache-solr/solr-operator#upgrading-the-solr-operator) to the same version**:
 
 ```bash
-helm upgrade example apache-solr/solr --version 0.6.0-prerelease --reuse-values --set image.tag=8.11
+helm upgrade example apache-solr/solr --version 0.6.0 --reuse-values --set image.tag=8.11
 ```
 
 The upgrade will be done according to the `upgradeStrategy.method` chosen in the values.

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -38,7 +38,7 @@ There may be breaking changes between the version you are using and the version 
 To install the Solr Operator for the first time in your cluster, you can use the latest version or a specific version, run with the following commands:
 
 ```bash
-helm install example apache-solr/solr --version 0.6.0 --set image.tag=8.8
+helm install example apache-solr/solr --version 0.6.1-prerelease --set image.tag=8.8
 ```
 
 The command deploys a SolrCloud object on the Kubernetes cluster with the default configuration.
@@ -52,7 +52,7 @@ _Note that the Helm chart version does not contain a `v` prefix, which the Solr 
 If you are upgrading your SolrCloud deployment, you should always use a specific version of the chart and upgrade **after [upgrading the Solr Operator](https://artifacthub.io/packages/helm/apache-solr/solr-operator#upgrading-the-solr-operator) to the same version**:
 
 ```bash
-helm upgrade example apache-solr/solr --version 0.6.0 --reuse-values --set image.tag=8.11
+helm upgrade example apache-solr/solr --version 0.6.1-prerelease --reuse-values --set image.tag=8.11
 ```
 
 The upgrade will be done according to the `upgradeStrategy.method` chosen in the values.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ package version
 var (
 	// Version information for the Solr Operator
 	Version       = "v0.6.0"
-	VersionSuffix = "prerelease"
+	VersionSuffix = ""
 	BuildTime     string
 	GitSHA        string
 )

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,8 @@ package version
 
 var (
 	// Version information for the Solr Operator
-	Version       = "v0.6.0"
-	VersionSuffix = ""
+	Version       = "v0.6.1"
+	VersionSuffix = "prerelease"
 	BuildTime     string
 	GitSHA        string
 )


### PR DESCRIPTION
Just a minor typographical correction in the descriptive title pertaining to one of the Helm Charts: A SolrCloud cluser running on Kubernetes via the Solr Operator. URL: https://artifacthub.io/packages/helm/apache-solr/solr
Cluser should be corrected to Cluster.
