### PR TITLE
Add Annotations to created ServiceAccount

### DIFF
--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -61,9 +61,9 @@ annotations:
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/481
     - kind: added
-      description: ServiceAccount annotations
+      description: Support custom annotations on created ServiceAccount
       links:
-        - name: GitHub PR 480
+        - name: GitHub PR
           url: https://github.com/apache/solr-operator/pull/480
   artifacthub.io/images: |
     - name: solr-operator

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -60,6 +60,11 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/479
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/481
+    - kind: added
+      description: ServiceAccount annotations
+      links:
+        - name: GitHub PR 480
+          url: https://github.com/apache/solr-operator/pull/480
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.7.0-prerelease

--- a/helm/solr-operator/templates/service_account.yaml
+++ b/helm/solr-operator/templates/service_account.yaml
@@ -17,9 +17,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.serviceAccount.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
   name: {{ include "solr-operator.serviceAccountName" . }}
 {{- end }}

--- a/helm/solr-operator/templates/service_account.yaml
+++ b/helm/solr-operator/templates/service_account.yaml
@@ -17,5 +17,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+  {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   name: {{ include "solr-operator.serviceAccountName" . }}
 {{- end }}

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -62,6 +62,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+  ## Annotations to be added to ServiceAccount
+  annotations: {}
+
 # Various Pod Options to customize the runtime of the operator
 resources: {}
 envVars: []

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -40,9 +40,9 @@ annotations:
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
     - kind: added
-      description: Add annotations to created ServiceAccount
+      description: Support custom annotations on created ServiceAccount
       links:
-        - name: GitHub PR 480
+        - name: GitHub PR
           url: https://github.com/apache/solr-operator/pull/480
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -40,15 +40,10 @@ annotations:
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
     - kind: added
-      description: Addition 1
+      description: Add annotations to created ServiceAccount
       links:
-        - name: Github Issue
-          url: https://github.com/issue-url
-    - kind: changed
-      description: Change 2
-      links:
-        - name: Github PR
-          url: https://github.com/pr-url
+        - name: GitHub PR 480
+          url: https://github.com/apache/solr-operator/pull/480
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator

--- a/helm/solr/templates/service_account.yaml
+++ b/helm/solr/templates/service_account.yaml
@@ -17,5 +17,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+  {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   name: {{ include "solr.serviceAccountName.global" . }}
 {{- end }}

--- a/helm/solr/templates/service_account.yaml
+++ b/helm/solr/templates/service_account.yaml
@@ -17,9 +17,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.serviceAccount.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
   name: {{ include "solr.serviceAccountName.global" . }}
 {{- end }}

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -36,6 +36,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+  ## Annotations to be added to ServiceAccount
+  annotations: {}
+
 image:
   repository: "solr"
   tag: ""


### PR DESCRIPTION
In order to support AWS IAM Role assumption via the [pod-identity-webhook](https://github.com/aws/amazon-eks-pod-identity-webhook), there need to be annotations added to the ServiceAccount.

This change enables users to add annotations to the ServiceAccount created for the SolrCloud instance.