### PR TITLE
Fix issue with namespaces in helm charts

### DIFF
--- a/hack/config/copy_crds_roles_helm.sh
+++ b/hack/config/copy_crds_roles_helm.sh
@@ -39,7 +39,7 @@ HELM_DIRECTORY="${HELM_DIRECTORY:-helm}"
 # Template the Solr Operator role as needed for Helm values
 {
   cat hack/headers/header.yaml.txt
-  printf '\n\n{{- if .Values.rbac.create }}\n{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}\n'
+  printf '\n\n{{- if .Values.rbac.create }}\n{{- range $namespace := (splitList "," (include "solr-operator.watchNamespaces" $)) }}\n'
   cat "${CONFIG_DIRECTORY}/rbac/role.yaml" \
     | awk '/^rules:$/{print "  namespace: {{ $namespace }}"}1' \
     | sed -E 's/^kind: ClusterRole$/kind: {{ include "solr-operator\.roleType" \$ }}/' \

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -79,6 +79,11 @@ annotations:
           url: https://github.com/apache/solr-operator/pull/473
         - name: PodDisruptionBudget Documentation
           url: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+    - kind: fixed
+      description: Fix namespace support for helm installation and leader election
+      links:
+        - name: GitHub PR
+          url: https://github.com/apache/solr-operator/pull/508
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.7.0-prerelease

--- a/helm/solr-operator/templates/_helpers.tpl
+++ b/helm/solr-operator/templates/_helpers.tpl
@@ -76,6 +76,13 @@ If .Values.watchNamespaces is empty or false, return empty.
 {{- end -}}
 
 {{/*
+What namespace to do leader election in
+*/}}
+{{- define "solr-operator.leaderElectionNamespace" -}}
+{{- (splitList "," (include "solr-operator.watchNamespaces" $)) | first | default $.Release.Namespace -}}
+{{- end -}}
+
+{{/*
 Determine whether to use ClusterRoles or Roles
 */}}
 {{- define "solr-operator.roleType" -}}

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -17,6 +17,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "solr-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: solr-operator
 spec:

--- a/helm/solr-operator/templates/leader_election_role.yaml
+++ b/helm/solr-operator/templates/leader_election_role.yaml
@@ -14,14 +14,13 @@
 # limitations under the License.
 
 {{- if .Values.leaderElection.enable }}
-{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
 ---
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "solr-operator.fullname" $ }}-leader-election-role
-  namespace: {{ $namespace }}
+  namespace: {{ include "solr-operator.leaderElectionNamespace" $ }}
 rules:
 - apiGroups:
   - ""
@@ -55,5 +54,4 @@ rules:
   - create
   - patch
 
-{{- end }}
 {{- end }}

--- a/helm/solr-operator/templates/leader_election_role_binding.yaml
+++ b/helm/solr-operator/templates/leader_election_role_binding.yaml
@@ -14,13 +14,12 @@
 # limitations under the License.
 
 {{- if .Values.leaderElection.enable }}
-{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "solr-operator.fullname" $ }}-leader-election-rolebinding
-  namespace: {{ $namespace }}
+  namespace: {{ include "solr-operator.leaderElectionNamespace" $ }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -30,5 +29,4 @@ subjects:
     name: {{ include "solr-operator.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
 
-{{- end }}
 {{- end }}

--- a/helm/solr-operator/templates/role.yaml
+++ b/helm/solr-operator/templates/role.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
+{{- range $namespace := (splitList "," (include "solr-operator.watchNamespaces" $)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ include "solr-operator.roleType" $ }}

--- a/helm/solr-operator/templates/role_binding.yaml
+++ b/helm/solr-operator/templates/role_binding.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
+{{- range $namespace := (splitList "," (include "solr-operator.watchNamespaces" $)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ include "solr-operator.roleType" $ }}Binding

--- a/helm/solr-operator/templates/service_account.yaml
+++ b/helm/solr-operator/templates/service_account.yaml
@@ -24,4 +24,5 @@ metadata:
     {{- end }}
   {{- end }}
   name: {{ include "solr-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -49,6 +49,11 @@ annotations:
       links:
         - name: GitHub PR
           url: https://github.com/apache/solr-operator/pull/480
+    - kind: fixed
+      description: Fix namespace support for helm installation
+      links:
+        - name: GitHub PR
+          url: https://github.com/apache/solr-operator/pull/508
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator

--- a/helm/solr/templates/service_account.yaml
+++ b/helm/solr/templates/service_account.yaml
@@ -24,4 +24,5 @@ metadata:
     {{- end }}
   {{- end }}
   name: {{ include "solr.serviceAccountName.global" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/solr/templates/solrcloud.yaml
+++ b/helm/solr/templates/solrcloud.yaml
@@ -17,6 +17,7 @@ apiVersion: solr.apache.org/v1beta1
 kind: SolrCloud
 metadata:
   name: {{ include "solr.fullname-no-suffix" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "solr.labels" . | nindent 4 }}
 spec:

--- a/main.go
+++ b/main.go
@@ -137,12 +137,13 @@ func main() {
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s / %s", runtime.GOOS, runtime.GOARCH))
 
 	operatorOptions := ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "88488bdc.solr.apache.org",
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		Port:                    9443,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionNamespace: namespace,
+		LeaderElectionID:        "88488bdc.solr.apache.org",
 	}
 
 	/*


### PR DESCRIPTION
There are a few issues with namespaces in the helm chart.

- Some resources use the current context's namespace instead of the release namespace.
- The helm chart sets RBAC for leader election in all watched namespaces. Only 1 namespace is necessary