### PR TITLE
Fix non-recurring backups

### DIFF
--- a/controllers/solrbackup_controller.go
+++ b/controllers/solrbackup_controller.go
@@ -92,6 +92,7 @@ func (r *SolrBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	requeueOrNot := reconcile.Result{}
 
+	// Backup work needs to be done by default if the current backup is not finished
 	doBackupWork := !backup.Status.IndividualSolrBackupStatus.Finished
 
 	// Check if we should start the next backup
@@ -123,7 +124,7 @@ func (r *SolrBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	// Do backup work if we are not waiting and the current backup is not finished
+	// Do backup work if a backup is in-progress or needs to be started
 	if doBackupWork {
 		solrCloud, _, err1 := r.reconcileSolrCloudBackup(ctx, backup, &backup.Status.IndividualSolrBackupStatus, logger)
 		if err1 != nil {

--- a/controllers/solrbackup_controller.go
+++ b/controllers/solrbackup_controller.go
@@ -92,17 +92,17 @@ func (r *SolrBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	requeueOrNot := reconcile.Result{}
 
-	var backupNeedsToWait bool
+	doBackupWork := !backup.Status.IndividualSolrBackupStatus.Finished
 
 	// Check if we should start the next backup
-	if backup.Status.NextScheduledTime != nil {
-		// If the backup no longer enabled, remove the next scheduled time
+	// Do not check if already doing a backup
+	if !doBackupWork && backup.Status.NextScheduledTime != nil {
 		if !backup.Spec.Recurrence.IsEnabled() {
 			backup.Status.NextScheduledTime = nil
-			backupNeedsToWait = false
+			doBackupWork = false
 		} else if backup.Status.NextScheduledTime.UTC().Before(time.Now().UTC()) {
 			// We have hit the next scheduled restart time.
-			backupNeedsToWait = false
+			doBackupWork = true
 			backup.Status.NextScheduledTime = nil
 
 			// Add the current backup to the front of the history.
@@ -119,14 +119,12 @@ func (r *SolrBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		} else {
 			// If we have not hit the next scheduled restart, wait to requeue until that is true.
 			updateRequeueAfter(&requeueOrNot, backup.Status.NextScheduledTime.UTC().Sub(time.Now().UTC()))
-			backupNeedsToWait = true
+			doBackupWork = false
 		}
-	} else {
-		backupNeedsToWait = false
 	}
 
 	// Do backup work if we are not waiting and the current backup is not finished
-	if !backupNeedsToWait && !backup.Status.IndividualSolrBackupStatus.Finished {
+	if doBackupWork {
 		solrCloud, _, err1 := r.reconcileSolrCloudBackup(ctx, backup, &backup.Status.IndividualSolrBackupStatus, logger)
 		if err1 != nil {
 			// TODO Should we be failing the backup for some sub-set of errors here?
@@ -146,7 +144,7 @@ func (r *SolrBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Schedule the next backupTime, if it doesn't have a next scheduled time, it has recurrence and the current backup is finished
-	if backup.Status.IndividualSolrBackupStatus.Finished {
+	if backup.Status.IndividualSolrBackupStatus.Finished && backup.Spec.Recurrence.IsEnabled() {
 		if nextBackupTime, err1 := util.ScheduleNextBackup(backup.Spec.Recurrence.Schedule, backup.Status.IndividualSolrBackupStatus.StartTime.Time); err1 != nil {
 			logger.Error(err1, "Could not update backup scheduling due to bad cron schedule", "cron", backup.Spec.Recurrence.Schedule)
 		} else {

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -84,6 +84,11 @@ annotations:
       links:
         - name: GitHub PR
           url: https://github.com/apache/solr-operator/pull/508
+    - kind: fixed
+      description: Fix bug in non-recurring SolrBackups
+      links:
+        - name: GitHub PR
+          url: https://github.com/apache/solr-operator/pull/509
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.7.0-prerelease


### PR DESCRIPTION
https://github.com/apache/solr-operator/pull/455 introduced a bug for non-recurring backups that was unearthed while working on https://github.com/apache/solr-operator/pull/507

Basically we need to only update the `NextScheduledTimestamp` if `recurrence` is enabled.

I also restructured the logic to hopefully make it more clear when backup logic should be run.