### PR TITLE
Zookeeper image should not default to pull Always

### DIFF
--- a/controllers/zk_api/zkcluster.go
+++ b/controllers/zk_api/zkcluster.go
@@ -29,7 +29,7 @@ const (
 	DefaultZkContainerVersion = "0.2.14"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
-	DefaultZkContainerPolicy = "Always"
+	DefaultZkContainerPolicy = v1.PullIfNotPresent
 
 	// DefaultTerminationGracePeriod is the default time given before the
 	// container is stopped. This gives clients time to disconnect from a

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -118,6 +118,8 @@ _Note that the Helm chart version does not contain a `v` prefix, which the downl
   The maximum number of pods allowed down at any given time is aligned with the [Managed Update settings](solr-cloud/solr-cloud-crd.md#update-strategy) provided in the spec.
   If this is not provided, the default setting (`25%`) is used.
 
+- Provided Zookeeper pods use the `IfNotPresent` pullPolicy by default. Users that specify this field manually will not see a change.
+
 ### v0.6.0
 - The default Solr version for the `SolrCloud` and `SolrPrometheusExporter` resources has been upgraded from `8.9` to `8.11`.
   This will not affect any existing resources, as default versions are hard-written to the resources immediately.

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -84,6 +84,11 @@ annotations:
       links:
         - name: GitHub PR
           url: https://github.com/apache/solr-operator/pull/508
+    - kind: changed
+      description: Zookeeper images now use the IfNotPresent pullPolicy by default
+      links:
+        - name: GitHub PR
+          url: https://github.com/apache/solr-operator/pull/512/files
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.7.0-prerelease


### PR DESCRIPTION
There is no reason why the zookeeper image would need an aggressive imagePullPolicy, especially since we are not using the `latest` tag. The default tag is set to the version of the zookeeper-operator that is supported by the Solr Operator.