### PR TITLE
Fix SolrBackup not taking backups when the collections field is omitted 

### DIFF
--- a/controllers/util/backup_util.go
+++ b/controllers/util/backup_util.go
@@ -210,3 +210,17 @@ func ScheduleNextBackup(restartSchedule string, lastBackupTime time.Time) (nextB
 	}
 	return
 }
+
+func ListAllSolrCollections(ctx context.Context, cloud *solr.SolrCloud, logger logr.Logger) (collections []string, err error) {
+	logger.Info("Listing all Solr collections available", "solrCloud", cloud.Name)
+	resp := &solr_api.SolrCollectionsListing{}
+	queryParams := url.Values{}
+	queryParams.Add("action", "LIST")
+	err = solr_api.CallCollectionsApi(ctx, cloud, queryParams, resp)
+	if err == nil {
+		if hasError, apiErr := solr_api.CheckForCollectionsApiError("LIST", resp.ResponseHeader); hasError {
+			err = apiErr
+		}
+	}
+	return resp.Collections, err
+}

--- a/controllers/util/solr_api/api.go
+++ b/controllers/util/solr_api/api.go
@@ -87,6 +87,13 @@ type SolrDeleteRequestStatus struct {
 	Status string `json:"status,omitempty"`
 }
 
+type SolrCollectionsListing struct {
+	ResponseHeader SolrResponseHeader `json:"responseHeader"`
+
+	// +optional
+	Collections []string `json:"collections,omitempty"`
+}
+
 func CheckAsyncRequest(ctx context.Context, cloud *solr.SolrCloud, asyncId string) (asyncState string, message string, err error) {
 	asyncStatus := &SolrAsyncStatusResponse{}
 

--- a/docs/solr-backup/README.md
+++ b/docs/solr-backup/README.md
@@ -97,6 +97,7 @@ spec:
 ```
 
 This will create a backup of both the 'techproducts' and 'books' collections, storing the data on the 'collection-backup-pvc' volume.
+If you don't specify the collections field, every available SolrCloud collection will be backed up.
 The status of our triggered backup can be checked with the command below.
 
 ```bash

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -101,6 +101,13 @@ annotations:
           url: https://github.com/apache/solr-operator/pull/514
         - name: GitHub Issue
           url: https://github.com/apache/solr-operator/issues/490
+    - kind: fixed
+      description: Fix SolrBackup not taking backups when the collections field is omitted 
+      links:
+        - name: GitHub PR
+          url: https://github.com/apache/solr-operator/pull/516
+        - name: GitHub Issue
+          url: https://github.com/apache/solr-operator/issues/515
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.7.0-prerelease


### PR DESCRIPTION
Resolves #515.

When there are no collections specified in the CRD, attempt to list them all from SolrCloud and back them up.