### PR TITLE
Use HPA v2 in tutorial

### DIFF
--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -183,7 +183,7 @@ kubectl get solrclouds -w
 The SolrCloud CRD is setup so that it is able to run with the HPA.
 Merely use the following when creating an HPA object:
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-solr
@@ -191,7 +191,7 @@ spec:
   maxReplicas: 6
   minReplicas: 3
   scaleTargetRef:
-    apiVersion: solr.apache.com/v1beta1
+    apiVersion: solr.apache.org/v1beta1
     kind: SolrCloud
     name: example
   metrics:


### PR DESCRIPTION
Updating the version of the Autoscaler as it's deprecated. 
`Warning: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler`

And fixing the apiVersion as it's '.org' and not '.com'
```
% kubectl api-resources -o wide | grep SolrCloud
solrclouds                        solr          solr.apache.org/v1beta1                true         SolrCloud 
```