### PR TITLE
Remove pod labels fix after zk-op upgrade

### DIFF
--- a/controllers/solrcloud_controller_zk_test.go
+++ b/controllers/solrcloud_controller_zk_test.go
@@ -19,7 +19,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	solrv1beta1 "github.com/apache/solr-operator/api/v1beta1"
@@ -295,14 +294,9 @@ var _ = FDescribe("SolrCloud controller - Zookeeper", func() {
 			// Documentation indicates that Spec.Labels is for passing pod labels.
 			// This test will remain here in case the behavior changes on the
 			// Zookeeper Operator in the future.
-			Expect(zkCluster.Spec.Pod.Labels).To(HaveKeyWithValue("app", "foo-solrcloud-zookeeper"), "Missing 'app' label from zkCluster pod labels")
-			Expect(zkCluster.Spec.Pod.Labels).To(HaveKeyWithValue("release", "foo-solrcloud-zookeeper"), "Missing 'release' label zkCluster pod labels")
-			Expect(zkCluster.Spec.Labels).To(HaveKeyWithValue("app", "foo-solrcloud-zookeeper"), "Missing 'app' label from zkCluster pod labels")
-			Expect(zkCluster.Spec.Labels).To(HaveKeyWithValue("release", "foo-solrcloud-zookeeper"), "Missing 'release' label zkCluster pod labels")
-			for k, v := range testSSLabels {
-				Expect(zkCluster.Spec.Pod.Labels).To(HaveKeyWithValue(k, v), fmt.Sprintf("Missing %s=%s from zkCluster pod labels", k, v))
-				Expect(zkCluster.Spec.Labels).To(HaveKeyWithValue(k, v), fmt.Sprintf("Missing %s=%s from zkCluster labels", k, v))
-			}
+			testZkPodLabels := util.MergeLabelsOrAnnotations(testSSLabels, map[string]string{"app": "foo-solrcloud-zookeeper", "release": "foo-solrcloud-zookeeper"})
+			Expect(zkCluster.Spec.Pod.Labels).To(Equal(testZkPodLabels), "Wrong zkCluster pod labels")
+			Expect(zkCluster.Spec.Labels).To(Not(Equal(testZkPodLabels)), "Wrong zkCluster labels")
 
 			// Check ZK Config Options
 			Expect(zkCluster.Spec.Conf.InitLimit).To(Equal(zkConf.InitLimit), "Incorrect zkCluster Config InitLimit")

--- a/controllers/util/zk_util.go
+++ b/controllers/util/zk_util.go
@@ -125,19 +125,7 @@ func GenerateZookeeperCluster(solrCloud *solrv1beta1.SolrCloud, zkSpec *solrv1be
 	}
 
 	if len(zkSpec.ZookeeperPod.Labels) > 0 {
-		// HACK: Include the pod labels on Spec.Labels due to
-		// https://github.com/pravega/zookeeper-operator/issues/511. See
-		// https://github.com/apache/solr-operator/issues/490 for more details.
-		// Note that the `labels` value should always take precedence over the pod
-		// specific labels.
-		podLabels := MergeLabelsOrAnnotations(labels, zkSpec.ZookeeperPod.Labels)
-
-		zkCluster.Spec.Pod.Labels = podLabels
-
-		// This override is applied to the zkCluster.Spec.Labels due to a bug in
-		// the zookeeper operator:
-		// https://github.com/pravega/zookeeper-operator/issues/511
-		zkCluster.Spec.Labels = podLabels
+		zkCluster.Spec.Pod.Labels = zkSpec.ZookeeperPod.Labels
 	}
 
 	if len(zkSpec.ZookeeperPod.Annotations) > 0 {
@@ -169,9 +157,6 @@ func GenerateZookeeperCluster(solrCloud *solrv1beta1.SolrCloud, zkSpec *solrv1be
 	}
 
 	// Add defaults that the ZK Operator should set itself, otherwise we will have problems with reconcile loops.
-	// Also it will default the spec.Probes object which cannot be set to null.
-	// TODO: Might be able to remove when the following is resolved and the dependency is upgraded:
-	// https://github.com/pravega/zookeeper-operator/issues/378
 	zkCluster.WithDefaults()
 	return zkCluster
 }

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -107,10 +107,10 @@ annotations:
     - kind: fixed
       description: Fix issue where Zookeeper specific labels are not propagated to Zookeeper pods
       links:
-        - name: GitHub PR
-          url: https://github.com/apache/solr-operator/pull/514
         - name: GitHub Issue
           url: https://github.com/apache/solr-operator/issues/490
+        - name: Zookeeper Operator Issue
+          url: https://github.com/pravega/zookeeper-operator/issues/511
     - kind: fixed
       description: Fix SolrBackup not taking backups when the collections field is omitted 
       links:


### PR DESCRIPTION
Resolves #490

The fix for Zookeeper pod labels is no longer necessary since #549 has been merged in for the `v0.7.0` release. We can go back to using the native Zookeeper operator logic to set pod labels.