### PR TITLE
Use DeferCleanup() and a sharedZK in e2e tests

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -1211,6 +1211,10 @@ func (sc *SolrCloud) GetAllSolrPodNames() []string {
 	return podNames
 }
 
+func (sc *SolrCloud) GetSolrPodName(podNumber int) string {
+	return fmt.Sprintf("%s-%d", sc.StatefulSetName(), podNumber)
+}
+
 func (sc *SolrCloud) BasicAuthSecretName() string {
 	if sc.Spec.SolrSecurity != nil && sc.Spec.SolrSecurity.BasicAuthSecret != "" {
 		return sc.Spec.SolrSecurity.BasicAuthSecret

--- a/tests/e2e/resource_utils_test.go
+++ b/tests/e2e/resource_utils_test.go
@@ -177,6 +177,35 @@ func expectSolrBackupWithConsistentChecks(ctx context.Context, solrBackup *solrv
 	return foundSolrBackup
 }
 
+func expectZookeeperCluster(ctx context.Context, parentResource client.Object, zkName string, additionalOffset ...int) *zkApi.ZookeeperCluster {
+	return expectZookeeperClusterWithChecks(ctx, parentResource, zkName, nil, resolveOffset(additionalOffset))
+}
+
+func expectZookeeperClusterWithChecks(ctx context.Context, parentResource client.Object, zkName string, additionalChecks func(Gomega, *zkApi.ZookeeperCluster), additionalOffset ...int) *zkApi.ZookeeperCluster {
+	found := &zkApi.ZookeeperCluster{}
+	EventuallyWithOffset(resolveOffset(additionalOffset), func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, resourceKey(parentResource, zkName), found)).To(Succeed(), "Expected ZookeeperCluster does not exist")
+		if additionalChecks != nil {
+			additionalChecks(g, found)
+		}
+	}).Should(Succeed())
+
+	return found
+}
+
+func expectZookeeperClusterWithConsistentChecks(ctx context.Context, parentResource client.Object, zkName string, additionalChecks func(Gomega, *zkApi.ZookeeperCluster), additionalOffset ...int) *zkApi.ZookeeperCluster {
+	found := &zkApi.ZookeeperCluster{}
+	ConsistentlyWithOffset(resolveOffset(additionalOffset), func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, resourceKey(parentResource, zkName), found)).To(Succeed(), "Expected ZookeeperCluster does not exist")
+
+		if additionalChecks != nil {
+			additionalChecks(g, found)
+		}
+	}).Should(Succeed())
+
+	return found
+}
+
 func expectSecret(ctx context.Context, parentResource client.Object, secretName string, additionalOffset ...int) *corev1.Secret {
 	return expectSecretWithChecks(ctx, parentResource, secretName, nil, resolveOffset(additionalOffset))
 }


### PR DESCRIPTION
When we increase the number of e2e tests, this will make them much faster, since each test won't need to wait a minute for Zookeeper to come up and Solr to become healthy.

We do need to include a new test that tests the provided Zookeeper cluster.