### PR TITLE
Make security context configurable.

### DIFF
--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -55,15 +55,10 @@ annotations:
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
     - kind: added
-      description: Addition 1
-      links:
-        - name: Github Issue
-          url: https://github.com/issue-url
-    - kind: changed
-      description: Change 2
+      description: K8s Security Context for solr-operator pod
       links:
         - name: Github PR
-          url: https://github.com/pr-url
+          url: https://github.com/apache/solr-operator/pull/566
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.8.0-prerelease

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -55,7 +55,7 @@ annotations:
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
   artifacthub.io/changes: |
     - kind: added
-      description: K8s Security Context for solr-operator pod
+      description: Ability to customize the SecurityContext for the solr-operator pod
       links:
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/566

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -182,6 +182,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.name | string | `""` | If `serviceAccount.create` is set to `false`, the name of an existing serviceAccount in the target namespace **must** be provided to run the Solr Operator with. This serviceAccount with be given the operator's RBAC rules. |
 | resources.limits | map[string]string |  | Provide Resource limits for the Solr Operator container |
 | resources.requests | map[string]string |  | Provide Resource requests for the Solr Operator container |
+| securityContext | map[string]string | `allowPrivilegeEscalation: false, runAsNonRoot: true` | Provide security context for the Solr Operator container |
 | labels | map[string]string |  | Custom labels to add to the Solr Operator pod |
 | annotations | map[string]string |  | Custom annotations to add to the Solr Operator pod |
 | nodeSelector | map[string]string |  | Add a node selector for the Solr Operator pod, to specify where it can be scheduled |

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -182,7 +182,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.name | string | `""` | If `serviceAccount.create` is set to `false`, the name of an existing serviceAccount in the target namespace **must** be provided to run the Solr Operator with. This serviceAccount with be given the operator's RBAC rules. |
 | resources.limits | map[string]string |  | Provide Resource limits for the Solr Operator container |
 | resources.requests | map[string]string |  | Provide Resource requests for the Solr Operator container |
-| securityContext | map[string]string | `allowPrivilegeEscalation: false, runAsNonRoot: true` | Provide security context for the Solr Operator container |
+| securityContext | object | `allowPrivilegeEscalation: false, runAsNonRoot: true` | Provide security context for the Solr Operator container |
 | labels | map[string]string |  | Custom labels to add to the Solr Operator pod |
 | annotations | map[string]string |  | Custom annotations to add to the Solr Operator pod |
 | nodeSelector | map[string]string |  | Add a node selector for the Solr Operator pod, to specify where it can be scheduled |

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -90,8 +90,7 @@ spec:
           {{- end }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          {{- toYaml .Values.securityContext | nindent 10 }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -67,6 +67,9 @@ serviceAccount:
 
 # Various Pod Options to customize the runtime of the operator
 resources: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
 envVars: []
 labels: {}
 annotations: {}


### PR DESCRIPTION
In order to comply to security policies (such as from Kyverno), make the k8s `securityContext` configurable via the helm chart values.