### PR TITLE
Add in a retry queue for clusterOps

### DIFF
--- a/controllers/solr_cluster_ops_util.go
+++ b/controllers/solr_cluster_ops_util.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	solrv1beta1 "github.com/apache/solr-operator/api/v1beta1"
 	"github.com/apache/solr-operator/controllers/util"
@@ -26,12 +27,109 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"time"
 )
+
+// SolrClusterOp contains metadata for cluster operations performed on SolrClouds.
+type SolrClusterOp struct {
+	// The type of Cluster Operation
+	Operation SolrClusterOperationType `json:"operation"`
+
+	// Time that the Cluster Operation was started or re-started
+	LastStartTime metav1.Time `json:"lastStartTime"`
+
+	// Time that the Cluster Operation was started or re-started
+	Metadata string `json:"metadata"`
+}
+type SolrClusterOperationType string
+
+const (
+	ScaleDownLock SolrClusterOperationType = "ScalingDown"
+	ScaleUpLock   SolrClusterOperationType = "ScalingUp"
+	UpdateLock    SolrClusterOperationType = "RollingUpdate"
+)
+
+func clearClusterOpLock(statefulSet *appsv1.StatefulSet) {
+	delete(statefulSet.Annotations, util.ClusterOpsLockAnnotation)
+}
+
+func setClusterOpLock(statefulSet *appsv1.StatefulSet, operation SolrClusterOperationType, metadata string) error {
+	clusterOp := SolrClusterOp{
+		Operation:     operation,
+		LastStartTime: metav1.Now(),
+		Metadata:      metadata,
+	}
+	bytes, err := json.Marshal(clusterOp)
+	if err != nil {
+		return err
+	}
+	statefulSet.Annotations[util.ClusterOpsLockAnnotation] = string(bytes)
+	return nil
+}
+
+func setClusterOpRetryQueue(statefulSet *appsv1.StatefulSet, queue []SolrClusterOp) error {
+	if len(queue) > 0 {
+		bytes, err := json.Marshal(queue)
+		if err != nil {
+			return err
+		}
+		statefulSet.Annotations[util.ClusterOpsRetryQueueAnnotation] = string(bytes)
+	} else {
+		delete(statefulSet.Annotations, util.ClusterOpsRetryQueueAnnotation)
+	}
+	return nil
+}
+
+func GetCurrentClusterOp(statefulSet *appsv1.StatefulSet) (clusterOp *SolrClusterOp, err error) {
+	if op, hasOp := statefulSet.Annotations[util.ClusterOpsLockAnnotation]; hasOp {
+		clusterOp = &SolrClusterOp{}
+		err = json.Unmarshal([]byte(op), clusterOp)
+	}
+	return
+}
+
+func GetClusterOpRetryQueue(statefulSet *appsv1.StatefulSet) (clusterOpQueue []SolrClusterOp, err error) {
+	if op, hasOp := statefulSet.Annotations[util.ClusterOpsRetryQueueAnnotation]; hasOp {
+		err = json.Unmarshal([]byte(op), &clusterOpQueue)
+	}
+	return
+}
+
+func enqueueCurrentClusterOpForRetry(statefulSet *appsv1.StatefulSet) (hasOp bool, err error) {
+	clusterOp, err := GetCurrentClusterOp(statefulSet)
+	if err != nil || clusterOp == nil {
+		return false, err
+	}
+	clusterOpRetryQueue, err := GetClusterOpRetryQueue(statefulSet)
+	if err != nil {
+		return true, err
+	}
+	clusterOpRetryQueue = append(clusterOpRetryQueue, *clusterOp)
+	clearClusterOpLock(statefulSet)
+	return true, setClusterOpRetryQueue(statefulSet, clusterOpRetryQueue)
+}
+
+func retryNextQueuedClusterOp(statefulSet *appsv1.StatefulSet) (hasOp bool, err error) {
+	clusterOpRetryQueue, err := GetClusterOpRetryQueue(statefulSet)
+	if err != nil {
+		return hasOp, err
+	}
+	hasOp = len(clusterOpRetryQueue) > 0
+	if len(clusterOpRetryQueue) > 0 {
+		nextOp := clusterOpRetryQueue[0]
+		err = setClusterOpLock(statefulSet, nextOp.Operation, nextOp.Metadata)
+		if err != nil {
+			return hasOp, err
+		}
+		err = setClusterOpRetryQueue(statefulSet, clusterOpRetryQueue[1:])
+	}
+	return hasOp, err
+}
 
 func determineScaleClusterOpLockIfNecessary(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, podList []corev1.Pod, logger logr.Logger) (clusterLockAcquired bool, retryLaterDuration time.Duration, err error) {
 	desiredPods := int(*instance.Spec.Replicas)
@@ -50,13 +148,15 @@ func determineScaleClusterOpLockIfNecessary(ctx context.Context, r *SolrCloudRec
 
 			// Managed Scale down!
 			originalStatefulSet := statefulSet.DeepCopy()
-			statefulSet.Annotations[util.ClusterOpsLockAnnotation] = util.ScaleDownLock
 			// The scaleDown metadata is the number of nodes to scale down to.
 			// We only support scaling down one pod at-a-time when using a managed scale-down.
 			// If the user wishes to scale down by multiple nodes, this ClusterOp will be done once-per-node.
-			statefulSet.Annotations[util.ClusterOpsMetadataAnnotation] = strconv.Itoa(configuredPods - 1)
-			if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-				logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", util.ScaleDownLock, "clusterOpMetadata", configuredPods-1)
+			err = setClusterOpLock(statefulSet, ScaleDownLock, strconv.Itoa(configuredPods-1))
+			if err == nil {
+				err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet))
+			}
+			if err != nil {
+				logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", ScaleDownLock, "clusterOpMetadata", configuredPods-1)
 			} else {
 				clusterLockAcquired = true
 			}
@@ -68,14 +168,16 @@ func determineScaleClusterOpLockIfNecessary(ctx context.Context, r *SolrCloudRec
 			}
 			// Managed Scale up!
 			originalStatefulSet := statefulSet.DeepCopy()
-			statefulSet.Annotations[util.ClusterOpsLockAnnotation] = util.ScaleUpLock
 			// The scaleUp metadata is the number of nodes that existed before the scaleUp.
 			// This allows the scaleUp operation to know which pods will be empty after the statefulSet is scaledUp.
-			statefulSet.Annotations[util.ClusterOpsMetadataAnnotation] = strconv.Itoa(configuredPods)
+			err = setClusterOpLock(statefulSet, ScaleUpLock, strconv.Itoa(configuredPods))
 			// We want to set the number of replicas at the beginning of the scaleUp operation
 			statefulSet.Spec.Replicas = pointer.Int32(int32(desiredPods))
-			if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-				logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", util.ScaleUpLock, "clusterOpMetadata", configuredPods, "newStatefulSetSize", desiredPods)
+			if err == nil {
+				err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet))
+			}
+			if err != nil {
+				logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", ScaleUpLock, "clusterOpMetadata", configuredPods, "newStatefulSetSize", desiredPods)
 			} else {
 				clusterLockAcquired = true
 			}
@@ -88,10 +190,10 @@ func determineScaleClusterOpLockIfNecessary(ctx context.Context, r *SolrCloudRec
 
 // handleManagedCloudScaleDown does the logic of a managed and "locked" cloud scale down operation.
 // This will likely take many reconcile loops to complete, as it is moving replicas away from the pods that will be scaled down.
-func handleManagedCloudScaleDown(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, scaleDownToRaw string, podList []corev1.Pod, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
+func handleManagedCloudScaleDown(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, opMeta *SolrClusterOp, podList []corev1.Pod, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
 	var scaleDownTo int
-	if scaleDownTo, err = strconv.Atoi(scaleDownToRaw); err != nil {
-		logger.Error(err, "Could not convert statefulSet annotation to int for scale-down-to information", "annotation", util.ClusterOpsMetadataAnnotation, "value", scaleDownToRaw)
+	if scaleDownTo, err = strconv.Atoi(opMeta.Metadata); err != nil {
+		logger.Error(err, "Could not convert statefulSet annotation to int for scale-down-to information", "annotation", util.ClusterOpsMetadataAnnotation, "value", opMeta.Metadata)
 		return
 		// TODO: Create event for the CRD.
 	}
@@ -99,7 +201,7 @@ func handleManagedCloudScaleDown(ctx context.Context, r *SolrCloudReconciler, in
 	if scaleDownTo >= int(*statefulSet.Spec.Replicas) {
 		// This shouldn't happen, but we don't want to be stuck if it does.
 		// Just remove the cluster Op, because the cluster has already been scaled down.
-		err = clearClusterOp(ctx, r, statefulSet, "statefulSet already scaled-down", logger)
+		err = clearClusterOpLockWithPatch(ctx, r, statefulSet, "statefulSet already scaled-down", logger)
 	}
 
 	// Before doing anything to the pod, make sure that users cannot send requests to the pod anymore.
@@ -114,16 +216,23 @@ func handleManagedCloudScaleDown(ctx context.Context, r *SolrCloudReconciler, in
 	// TODO: It would be great to support a multi-node scale down when Solr supports evicting many SolrNodes at once.
 	// Only evict the last pod, even if we are trying to scale down multiple pods.
 	// Scale down will happen one pod at a time.
-	if replicaManagementComplete, evictErr := evictSinglePod(ctx, r, instance, scaleDownTo, podList, podStoppedReadinessConditions, logger); err != nil {
+	if replicaManagementComplete, requestInProgress, evictErr := evictSinglePod(ctx, r, instance, scaleDownTo, podList, podStoppedReadinessConditions, logger); err != nil {
 		err = evictErr
 	} else if replicaManagementComplete {
 		originalStatefulSet := statefulSet.DeepCopy()
 		statefulSet.Spec.Replicas = pointer.Int32(int32(scaleDownTo))
-		delete(statefulSet.Annotations, util.ClusterOpsLockAnnotation)
-		delete(statefulSet.Annotations, util.ClusterOpsMetadataAnnotation)
+		clearClusterOpLock(statefulSet)
 		if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
 			logger.Error(err, "Error while patching StatefulSet to finish the managed SolrCloud scale down clusterOp", "newStatefulSetReplicas", scaleDownTo)
+		} else {
+			logger.Info("Removed unneeded clusterOpLock annotation from statefulSet", "reason", "Scale-down complete")
 		}
+
+		// TODO: Create event for the CRD.
+	} else if !requestInProgress && time.Since(opMeta.LastStartTime.Time) > time.Minute*10 {
+		// If the scaleDown operation is in a stoppable place (not currently doing an async operation)
+		// and the scaleDown has been taking more than 10 minutes, retry the scaleDown later.
+		err = enqueueCurrentClusterOpForRetryWithPatch(ctx, r, statefulSet, "Scale-down timed out during operation", logger)
 
 		// TODO: Create event for the CRD.
 	} else {
@@ -135,18 +244,18 @@ func handleManagedCloudScaleDown(ctx context.Context, r *SolrCloudReconciler, in
 
 // handleManagedCloudScaleUp does the logic of a managed and "locked" cloud scale up operation.
 // This will likely take many reconcile loops to complete, as it is moving replicas to the pods that have recently been scaled up.
-func handleManagedCloudScaleUp(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, scaleUpFromRaw string, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
-	// TODO: Think about bad pod specs, that will never come up healthy. We want to try a rolling restart in between if necessary
-	if balanceComplete, balanceErr := util.BalanceReplicasForCluster(ctx, instance, statefulSet, "scaleUp", scaleUpFromRaw, logger); err != nil {
+func handleManagedCloudScaleUp(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, opMeta *SolrClusterOp, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
+	if balanceComplete, requestInProgress, balanceErr := util.BalanceReplicasForCluster(ctx, instance, statefulSet, "scaleUp", opMeta.Metadata, logger); err != nil {
 		err = balanceErr
 	} else if balanceComplete {
 		// Once the replica balancing is complete, finish the cluster operation by deleting the statefulSet annotations
-		originalStatefulSet := statefulSet.DeepCopy()
-		delete(statefulSet.Annotations, util.ClusterOpsLockAnnotation)
-		delete(statefulSet.Annotations, util.ClusterOpsMetadataAnnotation)
-		if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-			logger.Error(err, "Error while patching StatefulSet to finish the managed SolrCloud scale up clusterOp")
-		}
+		err = clearClusterOpLockWithPatch(ctx, r, statefulSet, "Scale-up complete", logger)
+
+		// TODO: Create event for the CRD.
+	} else if !requestInProgress && time.Since(opMeta.LastStartTime.Time) > time.Minute*10 {
+		// If the scaleUp operation is in a stoppable place (not currently doing an async operation)
+		// and the scaleUp has been taking more than 10 minutes, retry the scaleUp later.
+		err = enqueueCurrentClusterOpForRetryWithPatch(ctx, r, statefulSet, "Scale-up timed out during operation", logger)
 
 		// TODO: Create event for the CRD.
 	} else {
@@ -160,11 +269,12 @@ func determineRollingUpdateClusterOpLockIfNecessary(ctx context.Context, r *Solr
 	if instance.Spec.UpdateStrategy.Method == solrv1beta1.ManagedUpdate && !outOfDatePods.IsEmpty() {
 		// Managed Rolling Upgrade!
 		originalStatefulSet := statefulSet.DeepCopy()
-		statefulSet.Annotations[util.ClusterOpsLockAnnotation] = util.UpdateLock
-		// No rolling update metadata is currently required
-		statefulSet.Annotations[util.ClusterOpsMetadataAnnotation] = ""
-		if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-			logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", util.UpdateLock, "clusterOpMetadata", "")
+		err = setClusterOpLock(statefulSet, UpdateLock, "")
+		if err == nil {
+			err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet))
+		}
+		if err != nil {
+			logger.Error(err, "Error while patching StatefulSet to start clusterOp", "clusterOp", UpdateLock, "clusterOpMetadata", "")
 		} else {
 			clusterLockAcquired = true
 		}
@@ -174,19 +284,13 @@ func determineRollingUpdateClusterOpLockIfNecessary(ctx context.Context, r *Solr
 
 // handleManagedCloudRollingUpdate does the logic of a managed and "locked" cloud rolling update operation.
 // This will take many reconcile loops to complete, as it is deleting pods/moving replicas.
-func handleManagedCloudRollingUpdate(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, outOfDatePods util.OutOfDatePodSegmentation, hasReadyPod bool, availableUpdatedPodCount int, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
+func handleManagedCloudRollingUpdate(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, opMeta *SolrClusterOp, outOfDatePods util.OutOfDatePodSegmentation, hasReadyPod bool, availableUpdatedPodCount int, logger logr.Logger) (retryLaterDuration time.Duration, err error) {
 	// Manage the updating of out-of-spec pods, if the Managed UpdateStrategy has been specified.
 	updateLogger := logger.WithName("ManagedUpdateSelector")
 
 	// First check if all pods are up to date. If so the rolling update is complete
 	if outOfDatePods.IsEmpty() {
-		// Once the rolling update is complete, finish the cluster operation by deleting the statefulSet annotations
-		originalStatefulSet := statefulSet.DeepCopy()
-		delete(statefulSet.Annotations, util.ClusterOpsLockAnnotation)
-		delete(statefulSet.Annotations, util.ClusterOpsMetadataAnnotation)
-		if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-			logger.Error(err, "Error while patching StatefulSet to finish the managed SolrCloud rollingUpdate clusterOp")
-		}
+		err = clearClusterOpLockWithPatch(ctx, r, statefulSet, "Rolling update complete", logger)
 
 		// TODO: Create event for the CRD.
 	} else {
@@ -210,8 +314,10 @@ func handleManagedCloudRollingUpdate(ctx context.Context, r *SolrCloudReconciler
 		}
 
 		// Only actually delete a running pod if it has been evicted, or doesn't need eviction (persistent storage)
+		requestInProgress := false
 		for _, pod := range podsToUpdate {
-			retryLaterDurationTemp, errTemp := DeletePodForUpdate(ctx, r, instance, &pod, podsHaveReplicas[pod.Name], updateLogger)
+			retryLaterDurationTemp, inProgTmp, errTemp := DeletePodForUpdate(ctx, r, instance, &pod, podsHaveReplicas[pod.Name], updateLogger)
+			requestInProgress = requestInProgress || inProgTmp
 
 			// Use the retryLaterDuration of the pod that requires a retry the soonest (smallest duration > 0)
 			if retryLaterDurationTemp > 0 && (retryLaterDurationTemp < retryLaterDuration || retryLaterDuration == 0) {
@@ -222,26 +328,64 @@ func handleManagedCloudRollingUpdate(ctx context.Context, r *SolrCloudReconciler
 			}
 		}
 
-		if retryLater && retryLaterDuration == 0 {
+		if !requestInProgress && time.Since(opMeta.LastStartTime.Time) > time.Minute*10 {
+			// If the rolling update operation is in a stoppable place (not currently doing an async operation)
+			// and the rolling update has been taking more than 10 minutes, retry the rolling update later.
+			// This is a perfectly acceptable place to be. We are giving other cluster operations the chance to operate
+			// while the update takes a break. If there are no other pending operations, the rolling update will restart
+			// immediately
+			err = enqueueCurrentClusterOpForRetryWithPatch(ctx, r, statefulSet, "Rolling-update timed out during operation", logger)
+
+			// TODO: Create event for the CRD.
+		} else if retryLater && retryLaterDuration == 0 {
 			retryLaterDuration = time.Second * 10
 		}
 	}
 	return
 }
 
-// clearClusterOp simply removes any clusterOp for the given statefulSet.
-// This should only be used as a "break-glass" scenario. Do not use this to finish off successful clusterOps.
-func clearClusterOp(ctx context.Context, r *SolrCloudReconciler, statefulSet *appsv1.StatefulSet, reason string, logger logr.Logger) (err error) {
-	logger = logger.WithValues("reason", reason, "clusterOp", statefulSet.Annotations[util.ClusterOpsLockAnnotation], "clusterOpMetadata", statefulSet.Annotations[util.ClusterOpsMetadataAnnotation])
+// clearClusterOpLockWithPatch simply removes any clusterOp for the given statefulSet.
+func clearClusterOpLockWithPatch(ctx context.Context, r *SolrCloudReconciler, statefulSet *appsv1.StatefulSet, reason string, logger logr.Logger) (err error) {
 	originalStatefulSet := statefulSet.DeepCopy()
-	delete(statefulSet.Annotations, util.ClusterOpsLockAnnotation)
-	delete(statefulSet.Annotations, util.ClusterOpsMetadataAnnotation)
+	clearClusterOpLock(statefulSet)
 	if err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet)); err != nil {
-		logger.Error(err, "Error while patching StatefulSet to remove unneeded clusterLockOp annotation")
+		logger.Error(err, "Error while patching StatefulSet to remove unneeded clusterOpLock annotation", "reason", reason)
 	} else {
-		logger.Error(err, "Removed unneeded clusterLockOp annotation from statefulSet")
+		logger.Info("Removed unneeded clusterOpLock annotation from statefulSet", "reason", reason)
 	}
 	return
+}
+
+// enqueueCurrentClusterOpForRetryWithPatch simply removes any clusterOp for the given statefulSet.
+// This should only be used as a "break-glass" scenario. Do not use this to finish off successful clusterOps.
+func enqueueCurrentClusterOpForRetryWithPatch(ctx context.Context, r *SolrCloudReconciler, statefulSet *appsv1.StatefulSet, reason string, logger logr.Logger) (err error) {
+	originalStatefulSet := statefulSet.DeepCopy()
+	hasOp, err := enqueueCurrentClusterOpForRetry(statefulSet)
+	if hasOp && err == nil {
+		err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet))
+	}
+	if err != nil {
+		logger.Error(err, "Error while patching StatefulSet to enqueue clusterOp for retry", "reason", reason)
+	} else if hasOp {
+		logger.Info("Enqueued current clusterOp for retry later", "reason", reason)
+	}
+	return err
+}
+
+// clearClusterOp simply removes any clusterOp for the given statefulSet.
+// This should only be used as a "break-glass" scenario. Do not use this to finish off successful clusterOps.
+func retryNextQueuedClusterOpWithPatch(ctx context.Context, r *SolrCloudReconciler, statefulSet *appsv1.StatefulSet, logger logr.Logger) (err error) {
+	originalStatefulSet := statefulSet.DeepCopy()
+	hasOp, err := retryNextQueuedClusterOp(statefulSet)
+	if hasOp && err == nil {
+		err = r.Patch(ctx, statefulSet, client.StrategicMergeFrom(originalStatefulSet))
+	}
+	if err != nil {
+		logger.Error(err, "Error while patching StatefulSet to retry next queued clusterOp")
+	} else if hasOp {
+		logger.Info("Retrying next queued clusterOp")
+	}
+	return err
 }
 
 // scaleCloudUnmanaged does simple scaling of a SolrCloud without moving replicas.
@@ -283,7 +427,7 @@ func evictAllPods(ctx context.Context, r *SolrCloudReconciler, instance *solrv1b
 	return
 }
 
-func evictSinglePod(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, scaleDownTo int, podList []corev1.Pod, readinessConditions map[corev1.PodConditionType]podReadinessConditionChange, logger logr.Logger) (podIsEmpty bool, err error) {
+func evictSinglePod(ctx context.Context, r *SolrCloudReconciler, instance *solrv1beta1.SolrCloud, scaleDownTo int, podList []corev1.Pod, readinessConditions map[corev1.PodConditionType]podReadinessConditionChange, logger logr.Logger) (podIsEmpty bool, requestInProgress bool, err error) {
 	var pod *corev1.Pod
 	podName := instance.GetSolrPodName(scaleDownTo)
 	for _, p := range podList {
@@ -295,14 +439,14 @@ func evictSinglePod(ctx context.Context, r *SolrCloudReconciler, instance *solrv
 
 	podHasReplicas := true
 	if replicas, e := getReplicasForPod(ctx, instance, podName, logger); e != nil {
-		return false, e
+		return false, false, e
 	} else {
 		podHasReplicas = len(replicas) > 0
 	}
 
 	// The pod doesn't exist, we cannot empty it
 	if pod == nil {
-		return !podHasReplicas, errors.New("Could not find pod " + podName + " when trying to migrate replicas to scale down pod.")
+		return !podHasReplicas, false, errors.New("Could not find pod " + podName + " when trying to migrate replicas to scale down pod.")
 	}
 
 	if updatedPod, e := EnsurePodReadinessConditions(ctx, r, pod, readinessConditions, logger); e != nil {
@@ -313,8 +457,8 @@ func evictSinglePod(ctx context.Context, r *SolrCloudReconciler, instance *solrv
 	}
 
 	// Only evict from the pod if it contains replicas in the clusterState
-	if e, canDeletePod := util.EvictReplicasForPodIfNecessary(ctx, instance, pod, podHasReplicas, "scaleDown", logger); e != nil {
-		err = e
+	var canDeletePod bool
+	if err, canDeletePod, requestInProgress = util.EvictReplicasForPodIfNecessary(ctx, instance, pod, podHasReplicas, "scaleDown", logger); err != nil {
 		logger.Error(err, "Error while evicting replicas on Pod, when scaling down SolrCloud", "pod", pod.Name)
 	} else if canDeletePod {
 		// The pod previously had replicas, so loop back in the next reconcile to make sure that the pod doesn't


### PR DESCRIPTION
Resolves #560

Fix the last remaining to-dos for safe lockable cluster operations. (Rolling Upgrade, Scale Up, Scale Down)

- Make the locks expire after a certain time (10 minutes), but when they expire they are put in a retryQueue.
- Other clusterOps will be run while its in the queue, but when no other clusterOps have to run, it will be pulled back off the queue.
- If a newer version of a clusterOp is available, the queued one should be abandoned in favor of the newer command. (scale up 3 ->5, queued, then scale down 5 -> 3, the scale up should not be continued if a scale down is necessary)

TODO:
- [ ] Retry Queue Implementation
- [ ] Replace ClusterOp with a newer version of the same op, if one exists
- [ ] Integration tests
- [ ] Documentation for user expectations
- [ ] Change log