### PR TITLE
Add option for explicit keystore/truststore password for mountedDir

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -1540,18 +1540,26 @@ type MountedTLSDirectory struct {
 	// +optional
 	KeystoreFile string `json:"keystoreFile,omitempty"`
 
-	// Override the name of the keystore password file; defaults to keystore-password
+	// Override the name of the keystore password file; defaults to keystore-password, if "keystorePassword" is not provided.
 	// +optional
 	KeystorePasswordFile string `json:"keystorePasswordFile,omitempty"`
+
+	// Set the password of the keystore explicitly. Cannot be used with "keystorePasswordFile"
+	// +optional
+	KeystorePassword string `json:"keystorePassword,omitempty"`
 
 	// Override the name of the truststore file; no default, if you don't supply this setting, then the corresponding
 	// env vars and Java system properties will not be configured for the pod template
 	// +optional
 	TruststoreFile string `json:"truststoreFile,omitempty"`
 
-	// Override the name of the truststore password file; defaults to the same value as the KeystorePasswordFile
+	// Override the name of the truststore password file; defaults to the same value as the KeystorePasswordFile, if "truststorePassword" is not provided.
 	// +optional
 	TruststorePasswordFile string `json:"truststorePasswordFile,omitempty"`
+
+	// Set the password of the truststore explicitly. If "keystorePassword" is provided, and "truststorePasswordFile" is not, this will be defaulted to "keystorePassword".
+	// +optional
+	TruststorePassword string `json:"truststorePassword,omitempty"`
 }
 
 type SolrTLSOptions struct {

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -9454,9 +9454,14 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      keystorePassword:
+                        description: Set the password of the keystore explicitly.
+                          Cannot be used with "keystorePasswordFile"
+                        type: string
                       keystorePasswordFile:
                         description: Override the name of the keystore password file;
-                          defaults to keystore-password
+                          defaults to keystore-password, if "keystorePassword" is
+                          not provided.
                         type: string
                       path:
                         description: The path on the main Solr container where the
@@ -9468,9 +9473,15 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      truststorePassword:
+                        description: Set the password of the truststore explicitly.
+                          If "keystorePassword" is provided, and "truststorePasswordFile"
+                          is not, this will be defaulted to "keystorePassword".
+                        type: string
                       truststorePasswordFile:
                         description: Override the name of the truststore password
-                          file; defaults to the same value as the KeystorePasswordFile
+                          file; defaults to the same value as the KeystorePasswordFile,
+                          if "truststorePassword" is not provided.
                         type: string
                     required:
                     - path
@@ -9704,9 +9715,14 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      keystorePassword:
+                        description: Set the password of the keystore explicitly.
+                          Cannot be used with "keystorePasswordFile"
+                        type: string
                       keystorePasswordFile:
                         description: Override the name of the keystore password file;
-                          defaults to keystore-password
+                          defaults to keystore-password, if "keystorePassword" is
+                          not provided.
                         type: string
                       path:
                         description: The path on the main Solr container where the
@@ -9718,9 +9734,15 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      truststorePassword:
+                        description: Set the password of the truststore explicitly.
+                          If "keystorePassword" is provided, and "truststorePasswordFile"
+                          is not, this will be defaulted to "keystorePassword".
+                        type: string
                       truststorePasswordFile:
                         description: Override the name of the truststore password
-                          file; defaults to the same value as the KeystorePasswordFile
+                          file; defaults to the same value as the KeystorePasswordFile,
+                          if "truststorePassword" is not provided.
                         type: string
                     required:
                     - path

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -7102,9 +7102,14 @@ spec:
                               corresponding env vars and Java system properties will
                               not be configured for the pod template
                             type: string
+                          keystorePassword:
+                            description: Set the password of the keystore explicitly.
+                              Cannot be used with "keystorePasswordFile"
+                            type: string
                           keystorePasswordFile:
                             description: Override the name of the keystore password
-                              file; defaults to keystore-password
+                              file; defaults to keystore-password, if "keystorePassword"
+                              is not provided.
                             type: string
                           path:
                             description: The path on the main Solr container where
@@ -7117,9 +7122,15 @@ spec:
                               corresponding env vars and Java system properties will
                               not be configured for the pod template
                             type: string
+                          truststorePassword:
+                            description: Set the password of the truststore explicitly.
+                              If "keystorePassword" is provided, and "truststorePasswordFile"
+                              is not, this will be defaulted to "keystorePassword".
+                            type: string
                           truststorePasswordFile:
                             description: Override the name of the truststore password
-                              file; defaults to the same value as the KeystorePasswordFile
+                              file; defaults to the same value as the KeystorePasswordFile,
+                              if "truststorePassword" is not provided.
                             type: string
                         required:
                         - path

--- a/controllers/util/solr_tls_util.go
+++ b/controllers/util/solr_tls_util.go
@@ -145,7 +145,7 @@ func (tls *TLSCerts) enableTLSOnSolrCloudStatefulSet(stateful *appsv1.StatefulSe
 		if tls.ClientConfig != nil && tls.ClientConfig.Options.PKCS12Secret != nil {
 			tls.ClientConfig.mountTLSSecretOnPodTemplate(&stateful.Spec.Template)
 		}
-	} else if serverCert.Options.MountedTLSDir != nil {
+	} else if tls.hasPasswordsInFiles() {
 		// the TLS files come from some auto-mounted directory on the main container
 		mountInitDbIfNeeded(stateful)
 		// use an initContainer to create the wrapper script in the initdb
@@ -334,6 +334,24 @@ func (tls *TLSConfig) volumesAndMounts() ([]corev1.Volume, []corev1.VolumeMount)
 	return vols, mounts
 }
 
+// Determine whether any passwords for Keystores/Truststores are stored in files
+func (tls *TLSCerts) hasPasswordsInFiles() (hasPasswordsInFiles bool) {
+	return tls != nil && (tls.ServerConfig.hasPasswordsInFiles() || tls.ClientConfig.hasPasswordsInFiles())
+}
+
+// Determine whether any passwords for Keystores/Truststores are stored in files
+func (tls *TLSConfig) hasPasswordsInFiles() (hasPasswordsInFiles bool) {
+	if tls != nil && tls.Options.MountedTLSDir != nil {
+		serverDir := tls.Options.MountedTLSDir
+		hasPasswordsInFiles = serverDir.KeystorePasswordFile != "" || serverDir.KeystorePassword == ""
+
+		if serverDir.TruststorePasswordFile != "" {
+			hasPasswordsInFiles = true
+		}
+	}
+	return
+}
+
 // Get the SOLR_SSL_* env vars for enabling TLS on Solr pods
 func (tls *TLSConfig) serverEnvVars() []corev1.EnvVar {
 	opts := tls.Options
@@ -376,7 +394,26 @@ func (tls *TLSConfig) serverEnvVars() []corev1.EnvVar {
 	if opts.MountedTLSDir != nil {
 		// TLS files are mounted by some external agent
 		envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_KEY_STORE", Value: mountedTLSKeystorePath(opts.MountedTLSDir)})
-		envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_TRUST_STORE", Value: mountedTLSTruststorePath(opts.MountedTLSDir)})
+		keyStorePassword := ""
+		if opts.MountedTLSDir.KeystorePassword != "" && opts.MountedTLSDir.KeystorePasswordFile == "" {
+			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_KEY_STORE_PASSWORD", Value: opts.MountedTLSDir.KeystorePassword})
+			keyStorePassword = opts.MountedTLSDir.KeystorePassword
+		}
+		if opts.MountedTLSDir.TruststoreFile != "" {
+			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_TRUST_STORE", Value: mountedTLSTruststorePath(opts.MountedTLSDir)})
+			trustStorePassword := opts.MountedTLSDir.TruststorePassword
+			if trustStorePassword == "" && keyStorePassword != "" {
+				trustStorePassword = keyStorePassword
+			}
+			if trustStorePassword != "" && opts.MountedTLSDir.TruststorePasswordFile == "" {
+				envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_TRUST_STORE_PASSWORD", Value: trustStorePassword})
+			}
+		} else {
+			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_TRUST_STORE", Value: mountedTLSKeystorePath(opts.MountedTLSDir)})
+			if keyStorePassword != "" {
+				envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_TRUST_STORE_PASSWORD", Value: keyStorePassword})
+			}
+		}
 	} else {
 		// keystore / truststore + passwords come from a secret
 		envVars = append(envVars, tls.keystoreEnvVars("SOLR_SSL_KEY_STORE")...)
@@ -390,14 +427,29 @@ func (tls *TLSConfig) serverEnvVars() []corev1.EnvVar {
 func (tls *TLSConfig) clientEnvVars() []corev1.EnvVar {
 	opts := tls.Options
 
-	envVars := []corev1.EnvVar{}
+	var envVars []corev1.EnvVar
 	if opts.MountedTLSDir != nil {
-		// passwords get exported from files in the TLS dir using an initdb wrapper script
+		// passwords get exported from files in the TLS dir using an initdb wrapper script if they come from files
+		keyStorePassword := ""
 		if opts.MountedTLSDir.KeystoreFile != "" {
 			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_KEY_STORE", Value: mountedTLSKeystorePath(opts.MountedTLSDir)})
+			if opts.MountedTLSDir.KeystorePassword != "" && opts.MountedTLSDir.KeystorePasswordFile == "" {
+				envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_KEY_STORE_PASSWORD", Value: opts.MountedTLSDir.KeystorePassword})
+				keyStorePassword = opts.MountedTLSDir.KeystorePassword
+			}
 		}
 		if opts.MountedTLSDir.TruststoreFile != "" {
 			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_TRUST_STORE", Value: mountedTLSTruststorePath(opts.MountedTLSDir)})
+			trustStorePassword := opts.MountedTLSDir.TruststorePassword
+			if trustStorePassword == "" && keyStorePassword != "" {
+				trustStorePassword = keyStorePassword
+			}
+			if trustStorePassword != "" && opts.MountedTLSDir.TruststorePasswordFile == "" {
+				envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD", Value: trustStorePassword})
+			}
+		} else if opts.MountedTLSDir.KeystoreFile != "" {
+			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_TRUST_STORE", Value: "$(SOLR_SSL_CLIENT_KEY_STORE)"})
+			envVars = append(envVars, corev1.EnvVar{Name: "SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD", Value: keyStorePassword})
 		}
 	}
 
@@ -541,21 +593,41 @@ func (tls *TLSConfig) mountTLSWrapperScriptAndInitContainer(deployment *appsv1.D
 // Create an initContainer that generates the initdb script that exports the keystore / truststore passwords stored in
 // a directory to the environment; this is only needed when using the mountedTLSDir approach
 func (tls *TLSCerts) generateTLSInitdbScriptInitContainer() corev1.Container {
-	// Might have a client cert too ...
-	exportClientPasswords := ""
-	if tls.ClientConfig != nil && tls.ClientConfig.Options.MountedTLSDir != nil {
+
+	exportServerKeystorePassword, exportServerTruststorePassword := "", ""
+	if tls.ServerConfig.Options.MountedTLSDir != nil {
 		mountedDir := tls.ClientConfig.Options.MountedTLSDir
-		if mountedDir.KeystorePasswordFile != "" {
-			exportClientPasswords += exportVarFromFileInInitdbWrapperScript("SOLR_SSL_CLIENT_KEY_STORE_PASSWORD", mountedTLSKeystorePasswordPath(mountedDir))
+		if mountedDir.KeystorePasswordFile != "" || mountedDir.KeystorePassword == "" {
+			exportServerKeystorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_KEY_STORE_PASSWORD", mountedTLSKeystorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
+			exportServerTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_TRUST_STORE_PASSWORD", "${SOLR_SSL_KEY_STORE_PASSWORD}")
 		}
-		exportClientPasswords += exportVarFromFileInInitdbWrapperScript("SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD", mountedTLSTruststorePasswordPath(mountedDir))
+		if mountedDir.TruststorePasswordFile != "" {
+			exportServerTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_KEY_STORE_PASSWORD", mountedTLSTruststorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
+		} else if mountedDir.TruststorePassword != "" {
+			exportServerTruststorePassword = ""
+		}
 	}
 
-	exportServerKeystorePassword := exportVarFromFileInInitdbWrapperScript("SOLR_SSL_KEY_STORE_PASSWORD", mountedTLSKeystorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
-	exportServerTruststorePassword := exportVarFromFileInInitdbWrapperScript("SOLR_SSL_TRUST_STORE_PASSWORD", mountedTLSTruststorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
+	// Might have a client cert too ...
+	exportClientKeystorePassword, exportClientTruststorePassword := "", ""
+	if tls.ClientConfig != nil && tls.ClientConfig.Options.MountedTLSDir != nil {
+		mountedDir := tls.ClientConfig.Options.MountedTLSDir
+		if mountedDir.KeystorePasswordFile != "" || mountedDir.KeystorePassword == "" {
+			exportClientKeystorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_CLIENT_KEY_STORE_PASSWORD", mountedTLSKeystorePasswordPath(mountedDir))
+			exportClientTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD", "${SOLR_SSL_CLIENT_KEY_STORE_PASSWORD}")
+		}
+		if mountedDir.TruststorePasswordFile == "" {
+			exportClientTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD", mountedTLSTruststorePasswordPath(mountedDir))
+		} else if mountedDir.TruststorePassword != "" {
+			exportClientTruststorePassword = ""
+		}
+	} else {
+		exportClientKeystorePassword = exportServerKeystorePassword
+		exportClientKeystorePassword = exportServerTruststorePassword
+	}
 
-	shCmd := fmt.Sprintf("echo -e \"#!/bin/bash\\n%s%s%s\"",
-		exportServerKeystorePassword, exportServerTruststorePassword, exportClientPasswords)
+	shCmd := fmt.Sprintf("echo -e \"#!/bin/bash\\n%s%s%s%s\"",
+		exportServerKeystorePassword, exportServerTruststorePassword, exportClientKeystorePassword, exportClientTruststorePassword)
 	shCmd += " > /docker-entrypoint-initdb.d/export-tls-vars.sh"
 	/*
 	   Init container creates a script like:
@@ -594,6 +666,7 @@ func (tls *TLSConfig) clientJavaOpts() []string {
 	}
 
 	if tls.Options.VerifyClientHostname {
+		// TODO: This is broken in Solr 9.2+
 		javaOpts = append(javaOpts, "-Dsolr.jetty.ssl.verifyClientHostName=HTTPS")
 	}
 
@@ -643,14 +716,24 @@ func (tls *TLSConfig) generatePkcs12InitContainer(imageName string, imagePullPol
 func secureProbeTLSJavaToolOpts(solrCloud *solr.SolrCloud) (tlsJavaToolOpts string, tlsJavaSysProps string) {
 	if solrCloud.Spec.SolrTLS != nil {
 		// prefer the mounted client cert for probes if provided
+		tlsDir := solrCloud.Spec.SolrTLS.MountedTLSDir
 		if solrCloud.Spec.SolrClientTLS != nil && solrCloud.Spec.SolrClientTLS.MountedTLSDir != nil {
+			tlsDir = solrCloud.Spec.SolrClientTLS.MountedTLSDir
+		}
+		if tlsDir != nil {
 			// The keystore passwords are in a file, then we need to cat the file(s) into JAVA_TOOL_OPTIONS
-			tlsJavaToolOpts += " -Djavax.net.ssl.keyStorePassword=$(cat " + mountedTLSKeystorePasswordPath(solrCloud.Spec.SolrClientTLS.MountedTLSDir) + ")"
-			tlsJavaToolOpts += " -Djavax.net.ssl.trustStorePassword=$(cat " + mountedTLSTruststorePasswordPath(solrCloud.Spec.SolrClientTLS.MountedTLSDir) + ")"
-		} else if solrCloud.Spec.SolrTLS.MountedTLSDir != nil {
-			// If the keystore passwords are in a file, then we need to cat the file(s) into JAVA_TOOL_OPTIONS
-			tlsJavaToolOpts += " -Djavax.net.ssl.keyStorePassword=$(cat " + mountedTLSKeystorePasswordPath(solrCloud.Spec.SolrTLS.MountedTLSDir) + ")"
-			tlsJavaToolOpts += " -Djavax.net.ssl.trustStorePassword=$(cat " + mountedTLSTruststorePasswordPath(solrCloud.Spec.SolrTLS.MountedTLSDir) + ")"
+			keyStorePassword := "$(cat " + mountedTLSKeystorePasswordPath(tlsDir) + ")"
+			if tlsDir.KeystorePasswordFile == "" && tlsDir.KeystorePassword != "" {
+				keyStorePassword = "${SOLR_SSL_CLIENT_KEY_STORE_PASSWORD}"
+			}
+			tlsJavaToolOpts += " -Djavax.net.ssl.keyStorePassword=" + keyStorePassword
+			trustStorePassword := keyStorePassword
+			if tlsDir.TruststorePasswordFile != "" {
+				trustStorePassword = "$(cat " + mountedTLSTruststorePasswordPath(tlsDir) + ")"
+			} else if tlsDir.TruststorePassword != "" {
+				trustStorePassword = tlsDir.TruststorePassword
+			}
+			tlsJavaToolOpts += " -Djavax.net.ssl.trustStorePassword=" + trustStorePassword
 		}
 		tlsJavaSysProps = secureProbeTLSJavaSysProps(solrCloud)
 	}

--- a/controllers/util/solr_tls_util.go
+++ b/controllers/util/solr_tls_util.go
@@ -596,13 +596,13 @@ func (tls *TLSCerts) generateTLSInitdbScriptInitContainer() corev1.Container {
 
 	exportServerKeystorePassword, exportServerTruststorePassword := "", ""
 	if tls.ServerConfig.Options.MountedTLSDir != nil {
-		mountedDir := tls.ClientConfig.Options.MountedTLSDir
+		mountedDir := tls.ServerConfig.Options.MountedTLSDir
 		if mountedDir.KeystorePasswordFile != "" || mountedDir.KeystorePassword == "" {
 			exportServerKeystorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_KEY_STORE_PASSWORD", mountedTLSKeystorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
 			exportServerTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_TRUST_STORE_PASSWORD", "${SOLR_SSL_KEY_STORE_PASSWORD}")
 		}
 		if mountedDir.TruststorePasswordFile != "" {
-			exportServerTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_KEY_STORE_PASSWORD", mountedTLSTruststorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
+			exportServerTruststorePassword = exportVarFromFileInInitdbWrapperScript("SOLR_SSL_TRUST_STORE_PASSWORD", mountedTLSTruststorePasswordPath(tls.ServerConfig.Options.MountedTLSDir))
 		} else if mountedDir.TruststorePassword != "" {
 			exportServerTruststorePassword = ""
 		}

--- a/docs/solr-cloud/solr-cloud-crd.md
+++ b/docs/solr-cloud/solr-cloud-crd.md
@@ -643,6 +643,12 @@ When using the mounted TLS directory option, you need to ensure each Solr pod ge
 Consequently, we recommend using the `spec.updateStrategy.restartSchedule` to restart pods before the certificate expires. 
 Typically, with this scheme, a new certificate is issued whenever a pod is restarted.
 
+When using the Cert Manager CSI Driver, a file is not generated for the keystore password.
+Instead, users can provide an annotation to manually set the password.
+For this use case, the `solrTLS.mountedTLSDir.keystorePassword` and `solrTLS.mountedTLSDir.truststorePassword` options are available.
+These take strings that are plain-text passwords for the keystore or truststore.
+They will be ignored when `keystorePasswordFile` and `truststorePasswordFile` are provided.
+
 ### Client TLS
 _Since v0.4.0_
 

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -114,6 +114,13 @@ annotations:
       links:
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/614
+    - kind: added
+      description: MountedDir TLS now accepts plaintext passwords, for use with the Cert Manager CSI Driver
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/603
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/608
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.8.0-prerelease

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -9703,9 +9703,14 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      keystorePassword:
+                        description: Set the password of the keystore explicitly.
+                          Cannot be used with "keystorePasswordFile"
+                        type: string
                       keystorePasswordFile:
                         description: Override the name of the keystore password file;
-                          defaults to keystore-password
+                          defaults to keystore-password, if "keystorePassword" is
+                          not provided.
                         type: string
                       path:
                         description: The path on the main Solr container where the
@@ -9717,9 +9722,15 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      truststorePassword:
+                        description: Set the password of the truststore explicitly.
+                          If "keystorePassword" is provided, and "truststorePasswordFile"
+                          is not, this will be defaulted to "keystorePassword".
+                        type: string
                       truststorePasswordFile:
                         description: Override the name of the truststore password
-                          file; defaults to the same value as the KeystorePasswordFile
+                          file; defaults to the same value as the KeystorePasswordFile,
+                          if "truststorePassword" is not provided.
                         type: string
                     required:
                     - path
@@ -9953,9 +9964,14 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      keystorePassword:
+                        description: Set the password of the keystore explicitly.
+                          Cannot be used with "keystorePasswordFile"
+                        type: string
                       keystorePasswordFile:
                         description: Override the name of the keystore password file;
-                          defaults to keystore-password
+                          defaults to keystore-password, if "keystorePassword" is
+                          not provided.
                         type: string
                       path:
                         description: The path on the main Solr container where the
@@ -9967,9 +9983,15 @@ spec:
                           env vars and Java system properties will not be configured
                           for the pod template
                         type: string
+                      truststorePassword:
+                        description: Set the password of the truststore explicitly.
+                          If "keystorePassword" is provided, and "truststorePasswordFile"
+                          is not, this will be defaulted to "keystorePassword".
+                        type: string
                       truststorePasswordFile:
                         description: Override the name of the truststore password
-                          file; defaults to the same value as the KeystorePasswordFile
+                          file; defaults to the same value as the KeystorePasswordFile,
+                          if "truststorePassword" is not provided.
                         type: string
                     required:
                     - path
@@ -24078,9 +24100,14 @@ spec:
                               corresponding env vars and Java system properties will
                               not be configured for the pod template
                             type: string
+                          keystorePassword:
+                            description: Set the password of the keystore explicitly.
+                              Cannot be used with "keystorePasswordFile"
+                            type: string
                           keystorePasswordFile:
                             description: Override the name of the keystore password
-                              file; defaults to keystore-password
+                              file; defaults to keystore-password, if "keystorePassword"
+                              is not provided.
                             type: string
                           path:
                             description: The path on the main Solr container where
@@ -24093,9 +24120,15 @@ spec:
                               corresponding env vars and Java system properties will
                               not be configured for the pod template
                             type: string
+                          truststorePassword:
+                            description: Set the password of the truststore explicitly.
+                              If "keystorePassword" is provided, and "truststorePasswordFile"
+                              is not, this will be defaulted to "keystorePassword".
+                            type: string
                           truststorePasswordFile:
                             description: Override the name of the truststore password
-                              file; defaults to the same value as the KeystorePasswordFile
+                              file; defaults to the same value as the KeystorePasswordFile,
+                              if "truststorePassword" is not provided.
                             type: string
                         required:
                         - path

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -233,8 +233,10 @@ Solr TLS is disabled by default. Provide any of the following to enable it.
 | solrTLS.mountedTLSDir.path | string | | The path on the main Solr container where the TLS files are mounted by some external agent or CSI Driver |
 | solrTLS.mountedTLSDir.keystoreFile | string | | Name of the keystore file in the mounted directory |
 | solrTLS.mountedTLSDir.keystorePasswordFile | string | | Override the name of the keystore password file; defaults to keystore-password |
+| solrTLS.mountedTLSDir.keystorePassword | string | | Manually set the keystore password, in plaintext; will be ignored if `keystorePasswordFile` is provided. Useful when using the Cert Manager CSI Driver. |
 | solrTLS.mountedTLSDir.truststoreFile | string | | Name of the truststore file in the mounted directory |
 | solrTLS.mountedTLSDir.truststorePasswordFile | string | | Override the name of the truststore password file; defaults to the same value as the KeystorePasswordFile |
+| solrTLS.mountedTLSDir.truststorePassword | string | | Manually set the truststore password, in plaintext; will be ignored if `truststorePasswordFile` is provided. Defaults to `keystorePassword`, if it is provided. |
 
 #### Client TLS Options
 
@@ -255,8 +257,10 @@ Configure Solr to use a separate TLS certificate for client auth.
 | solrClientTLS.mountedTLSDir.path | string | | The path on the main Solr container where the TLS files are mounted by some external agent or CSI Driver |
 | solrClientTLS.mountedTLSDir.keystoreFile | string | | Name of the keystore file in the mounted directory |
 | solrClientTLS.mountedTLSDir.keystorePasswordFile | string | | Override the name of the keystore password file; defaults to keystore-password |
+| solrClientTLS.mountedTLSDir.keystorePassword | string | | Manually set the keystore password, in plaintext; will be ignored if `keystorePasswordFile` is provided. Useful when using the Cert Manager CSI Driver. |
 | solrClientTLS.mountedTLSDir.truststoreFile | string | | Name of the truststore file in the mounted directory |
 | solrClientTLS.mountedTLSDir.truststorePasswordFile | string | | Override the name of the truststore password file; defaults to the same value as the KeystorePasswordFile |
+| solrClientTLS.mountedTLSDir.truststorePassword | string | | Manually set the truststore password, in plaintext; will be ignored if `truststorePasswordFile` is provided. Defaults to `keystorePassword`, if it is provided. |
 
 ### Global Options
 

--- a/helm/solr/values.yaml
+++ b/helm/solr/values.yaml
@@ -256,8 +256,10 @@ solrTLS: {}
   #   path: /path/to/mounted/tls
   #   keystoreFile: "keystore.p12"
   #   keystorePasswordFile: ""
+  #   keystorePassword: ""
   #   truststoreFile: "truststore.p12"
   #   truststorePasswordFile: ""
+  #   truststorePassword: ""
 
 solrClientTLS: {}
   # pkcs12Secret:
@@ -276,8 +278,10 @@ solrClientTLS: {}
   #   path: /path/to/mounted/tls
   #   keystoreFile: "keystore.p12"
   #   keystorePasswordFile: ""
+  #   keystorePassword: ""
   #   truststoreFile: "truststore.p12"
   #   truststorePasswordFile: ""
+  #   truststorePassword: ""
 
 # Customize the Solr Pod for your needs
 podOptions:


### PR DESCRIPTION
Resolves #603

The Cert Manager CSI Driver only accepts a string password when creating pkcs12 keystores, so we need to support this.

This will be tested by #605 , which isn't great, but any issues will be fixed there.

TODO:

- [x] Changelog entry
- [x] Helm Chart
- [x] Documentation