### PR TITLE
Fix rolling restarts

### DIFF
--- a/controllers/solr_pod_lifecycle_util.go
+++ b/controllers/solr_pod_lifecycle_util.go
@@ -101,6 +101,7 @@ func DeletePodForUpdate(ctx context.Context, r *SolrCloudReconciler, instance *s
 
 	// Delete the pod
 	if deletePod {
+		logger.Error(err, "Deleting solr pod for update", "pod", pod.Name)
 		err = r.Delete(ctx, pod, client.Preconditions{
 			UID: &pod.UID,
 		})

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -102,6 +102,11 @@ annotations:
           url: https://github.com/apache/solr-operator/pull/596
         - name: Documentation
           url: https://apache.github.io/solr-operator/docs/solr-cloud/cluster-operations.html#avoiding-deadlocks
+    - kind: added
+      description: Fix a bug with Rolling Restarts with ephemeral data
+      links:
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/614
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.8.0-prerelease


### PR DESCRIPTION
There was a bug introduced at some point, that once a deletion of a node was determined, if there was an error while moving replicas off of the node, then the operator was likely to delete the pod without retrying to move the replicas.

I've restructured the logic around fetching cluster state information, so that its very clear where the information is coming from when making these choices.