### PR TITLE
Add maxBooleanClauses setting to default solr.xml

### DIFF
--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -785,6 +785,7 @@ const DefaultSolrXML = `<?xml version="1.0" encoding="UTF-8" ?>
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
   </shardHandlerFactory>
+  <int name="maxBooleanClauses">${solr.max.booleanClauses:1024}</int>
   %s
 </solr>
 `

--- a/helm/solr/Chart.yaml
+++ b/helm/solr/Chart.yaml
@@ -48,6 +48,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/616
         - name: Version Compatibility Documentation
           url: https://apache.github.io/solr-operator/docs/upgrade-notes.html#solr-versions
+    - kind: changed
+      description: The default solr.xml now includes a `maxBooleanClauses` value of `${solr.max.booleanClauses:1024}`.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/630
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/631
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator


### PR DESCRIPTION
This allows us to take advantage of the additional "safety-valve" setting added in SOLR-13336 back in Solr 8.1!