### PR TITLE
Default to Solr 8.11 for e2e tests

### DIFF
--- a/tests/scripts/manage_e2e_tests.sh
+++ b/tests/scripts/manage_e2e_tests.sh
@@ -76,7 +76,7 @@ if [[ -z "${KUBERNETES_VERSION:-}" ]]; then
   KUBERNETES_VERSION="v1.26.6"
 fi
 if [[ -z "${SOLR_IMAGE:-}" ]]; then
-  SOLR_IMAGE="${SOLR_VERSION:-9.3}"
+  SOLR_IMAGE="${SOLR_VERSION:-8.11.2}"
 fi
 if [[ "${SOLR_IMAGE}" != *":"* ]]; then
   SOLR_IMAGE="solr:${SOLR_IMAGE}"


### PR DESCRIPTION
SOLR-16933 has been fixed for 9.4, but still exists in earlier releases in the 9.x line where it causes a number of e2e tests to fail their assertions.

This commit is meant to workaround this problem until a 9.4 docker image is available by defaulting the e2e tests to Solr 8.11.2