### PR TITLE
Get correct SolrPods in SolrCloud controller

### DIFF
--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -437,16 +437,21 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Get the SolrCloud's Pods and initialize them if necessary
 	var podList []corev1.Pod
 	var podSelector labels.Selector
-	if podSelector, podList, err = r.initializePods(ctx, instance, logger); err != nil {
+	if podSelector, podList, err = r.initializePods(ctx, instance, statefulSet, logger); err != nil {
 		return requeueOrNot, err
 	}
 
 	// Make sure the SolrCloud status is up-to-date with the state of the cluster
 	var outOfDatePods util.OutOfDatePodSegmentation
 	var availableUpdatedPodCount int
-	outOfDatePods, availableUpdatedPodCount, err = createCloudStatus(instance, &newStatus, statefulSet.Status, podSelector, podList)
+	var shouldRequeue bool
+	outOfDatePods, availableUpdatedPodCount, shouldRequeue, err = createCloudStatus(instance, &newStatus, statefulSet.Status, podSelector, podList)
 	if err != nil {
 		return requeueOrNot, err
+	} else if shouldRequeue {
+		// There is an issue with the status, so requeue to get a more up-to-date view of the cluster
+		updateRequeueAfter(&requeueOrNot, time.Second*1)
+		return requeueOrNot, nil
 	}
 
 	// We only want to do one cluster operation at a time, so we use a lock to ensure that.
@@ -620,7 +625,7 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // InitializePods Ensure that all SolrCloud Pods are initialized
-func (r *SolrCloudReconciler) initializePods(ctx context.Context, solrCloud *solrv1beta1.SolrCloud, logger logr.Logger) (podSelector labels.Selector, podList []corev1.Pod, err error) {
+func (r *SolrCloudReconciler) initializePods(ctx context.Context, solrCloud *solrv1beta1.SolrCloud, statefulSet *appsv1.StatefulSet, logger logr.Logger) (podSelector labels.Selector, podList []corev1.Pod, err error) {
 	foundPods := &corev1.PodList{}
 	selectorLabels := solrCloud.SharedLabels()
 	selectorLabels["technology"] = solrv1beta1.SolrTechnologyLabel
@@ -635,14 +640,24 @@ func (r *SolrCloudReconciler) initializePods(ctx context.Context, solrCloud *sol
 		logger.Error(err, "Error listing pods for SolrCloud")
 		return
 	}
-	podList = foundPods.Items
 
 	// Initialize the pod's notStopped readinessCondition so that they can receive traffic until they are stopped
-	for i, pod := range podList {
+	for _, pod := range foundPods.Items {
+		isOwnedByCurrentStatefulSet := false
+		for _, ownerRef := range pod.ObjectMeta.OwnerReferences {
+			if ownerRef.UID == statefulSet.UID {
+				isOwnedByCurrentStatefulSet = true
+				break
+			}
+		}
+		// Do not include pods that match, but are not owned by the current statefulSet
+		if !isOwnedByCurrentStatefulSet {
+			continue
+		}
 		if updatedPod, podError := r.initializePod(ctx, &pod, logger); podError != nil {
 			err = podError
 		} else if updatedPod != nil {
-			podList[i] = *updatedPod
+			podList = append(podList, *updatedPod)
 		}
 	}
 	return
@@ -676,7 +691,7 @@ func (r *SolrCloudReconciler) initializePod(ctx context.Context, pod *corev1.Pod
 // Initialize the SolrCloud.Status object
 func createCloudStatus(solrCloud *solrv1beta1.SolrCloud,
 	newStatus *solrv1beta1.SolrCloudStatus, statefulSetStatus appsv1.StatefulSetStatus, podSelector labels.Selector,
-	podList []corev1.Pod) (outOfDatePods util.OutOfDatePodSegmentation, availableUpdatedPodCount int, err error) {
+	podList []corev1.Pod) (outOfDatePods util.OutOfDatePodSegmentation, availableUpdatedPodCount int, shouldRequeue bool, err error) {
 	var otherVersions []string
 	nodeNames := make([]string, len(podList))
 	nodeStatusMap := map[string]solrv1beta1.SolrNodeStatus{}
@@ -798,8 +813,9 @@ func createCloudStatus(solrCloud *solrv1beta1.SolrCloud,
 		extAddress := solrCloud.UrlScheme(true) + "://" + solrCloud.ExternalCommonUrl(solrCloud.Spec.SolrAddressability.External.DomainName, true)
 		newStatus.ExternalCommonAddress = &extAddress
 	}
+	shouldRequeue = newStatus.ReadyReplicas != statefulSetStatus.ReadyReplicas || newStatus.Replicas != statefulSetStatus.Replicas || newStatus.UpToDateNodes != statefulSetStatus.UpdatedReplicas
 
-	return outOfDatePods, availableUpdatedPodCount, nil
+	return outOfDatePods, availableUpdatedPodCount, shouldRequeue, nil
 }
 
 func (r *SolrCloudReconciler) reconcileNodeService(ctx context.Context, logger logr.Logger, instance *solrv1beta1.SolrCloud, nodeName string) (err error, ip string) {

--- a/controllers/util/solr_security_util.go
+++ b/controllers/util/solr_security_util.go
@@ -499,7 +499,7 @@ func useSecureProbe(solrCloud *solr.SolrCloud, probe *corev1.Probe, mountPath st
 		javaToolOptionsStr = ""
 	}
 
-	probeCommand := fmt.Sprintf("%ssolr api -get \"%s://%s:%d%s\"", javaToolOptionsStr, solrCloud.UrlScheme(false), "${POD_NAME}", probe.HTTPGet.Port.IntVal, probe.HTTPGet.Path)
+	probeCommand := fmt.Sprintf("%ssolr api -get \"%s://${SOLR_HOST}:%d%s\"", javaToolOptionsStr, solrCloud.UrlScheme(false), probe.HTTPGet.Port.IntVal, probe.HTTPGet.Path)
 	probeCommand = regexp.MustCompile(`\s+`).ReplaceAllString(strings.TrimSpace(probeCommand), " ")
 
 	// use an Exec instead of an HTTP GET

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -328,6 +328,15 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 			},
 		},
 		{
+			Name: "POD_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath:  "status.podIP",
+					APIVersion: "v1",
+				},
+			},
+		},
+		{
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"io"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -291,7 +292,7 @@ func writeAllSolrInfoToFiles(ctx context.Context, directory string, namespace st
 	}
 
 	foundPods := &corev1.PodList{}
-	Expect(k8sClient.List(ctx, foundPods, listOps)).To(Succeed(), "Could not fetch Solr Operator pod")
+	Expect(k8sClient.List(ctx, foundPods, listOps)).To(Succeed(), "Could not fetch Solr pods")
 	Expect(foundPods).ToNot(BeNil(), "No Solr pods could be found")
 	for _, pod := range foundPods.Items {
 		writeAllPodInfoToFiles(
@@ -300,6 +301,42 @@ func writeAllSolrInfoToFiles(ctx context.Context, directory string, namespace st
 			&pod,
 		)
 	}
+
+	foundStatefulSets := &appsv1.StatefulSetList{}
+	Expect(k8sClient.List(ctx, foundStatefulSets, listOps)).To(Succeed(), "Could not fetch Solr statefulSets")
+	Expect(foundStatefulSets).ToNot(BeNil(), "No Solr statefulSet could be found")
+	for _, statefulSet := range foundStatefulSets.Items {
+		writeAllStatefulSetInfoToFiles(
+			directory+statefulSet.Name+".statefulSet",
+			&statefulSet,
+		)
+	}
+}
+
+// writeAllStatefulSetInfoToFiles writes the following each to a separate file with the given base name & directory.
+//   - StatefulSet Spec/Status
+//   - StatefulSet Events
+func writeAllStatefulSetInfoToFiles(baseFilename string, statefulSet *appsv1.StatefulSet) {
+	// Write statefulSet to a file
+	statusFile, err := os.Create(baseFilename + ".status.json")
+	defer statusFile.Close()
+	Expect(err).ToNot(HaveOccurred(), "Could not open file to save statefulSet status: %s", baseFilename+".status.json")
+	jsonBytes, marshErr := json.MarshalIndent(statefulSet, "", "\t")
+	Expect(marshErr).ToNot(HaveOccurred(), "Could not serialize statefulSet json")
+	_, writeErr := statusFile.Write(jsonBytes)
+	Expect(writeErr).ToNot(HaveOccurred(), "Could not write statefulSet json to file")
+
+	// Write events for statefulSet to a file
+	eventsFile, err := os.Create(baseFilename + ".events.json")
+	defer eventsFile.Close()
+	Expect(err).ToNot(HaveOccurred(), "Could not open file to save statefulSet events: %s", baseFilename+".events.yaml")
+
+	eventList, err := rawK8sClient.CoreV1().Events(statefulSet.Namespace).Search(scheme.Scheme, statefulSet)
+	Expect(err).ToNot(HaveOccurred(), "Could not find events for statefulSet: %s", statefulSet.Name)
+	jsonBytes, marshErr = json.MarshalIndent(eventList, "", "\t")
+	Expect(marshErr).ToNot(HaveOccurred(), "Could not serialize statefulSet events json")
+	_, writeErr = eventsFile.Write(jsonBytes)
+	Expect(writeErr).ToNot(HaveOccurred(), "Could not write statefulSet events json to file")
 }
 
 // writeAllPodInfoToFile writes the following each to a separate file with the given base name & directory.
@@ -319,24 +356,26 @@ func writeAllPodInfoToFiles(ctx context.Context, baseFilename string, pod *corev
 	// Write events for pod to a file
 	eventsFile, err := os.Create(baseFilename + ".events.json")
 	defer eventsFile.Close()
-	Expect(err).ToNot(HaveOccurred(), "Could not open file to save status: %s", baseFilename+".events.yaml")
+	Expect(err).ToNot(HaveOccurred(), "Could not open file to save pod events: %s", baseFilename+".events.yaml")
 
 	eventList, err := rawK8sClient.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
 	Expect(err).ToNot(HaveOccurred(), "Could not find events for pod: %s", pod.Name)
 	jsonBytes, marshErr = json.MarshalIndent(eventList, "", "\t")
-	Expect(marshErr).ToNot(HaveOccurred(), "Could not serialize events json")
+	Expect(marshErr).ToNot(HaveOccurred(), "Could not serialize pod events json")
 	_, writeErr = eventsFile.Write(jsonBytes)
-	Expect(writeErr).ToNot(HaveOccurred(), "Could not write events json to file")
+	Expect(writeErr).ToNot(HaveOccurred(), "Could not write pod events json to file")
 
 	// Write pod logs to a file
-	writePodLogsToFile(
-		ctx,
-		baseFilename+".log",
-		pod.Name,
-		pod.Namespace,
-		nil,
-		"",
-	)
+	if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Started != nil && *pod.Status.ContainerStatuses[0].Started {
+		writePodLogsToFile(
+			ctx,
+			baseFilename+".log",
+			pod.Name,
+			pod.Namespace,
+			nil,
+			"",
+		)
+	}
 }
 
 func writePodLogsToFile(ctx context.Context, filename string, podName string, podNamespace string, startTimeRaw *time.Time, filterLinesWithString string) {


### PR DESCRIPTION
The SolrCloud controller needs to fetch the list of Solr Pods for a given SolrCloud, in order to determine what to restart and construct the SolrCloud.Status object. However, when an old SolrCloud has been deleted and a new SolrCloud has been created (with the same name), there may be time when the new SolrCloud has been created, but the Pods for the old SolrCloud have not yet been deleted. So the SolrCloud controller will then think that the old Pods are related to the new SolrCloud, because they have the right labels. This isn't the case however, so we need to make sure that only the SolrCloud Pods that are actually related to that SolrCloud are fetched.

This is unlikely to show up in a production setting, but it causes havoc with the integration tests more than occasionally.

I have also added the StatefulSet json to the output for integration tests, allowing us to better debug failures.