### PR TITLE
Use 9.4 as the default e2e-tests Solr version

### DIFF
--- a/tests/scripts/manage_e2e_tests.sh
+++ b/tests/scripts/manage_e2e_tests.sh
@@ -76,7 +76,7 @@ if [[ -z "${KUBERNETES_VERSION:-}" ]]; then
   KUBERNETES_VERSION="v1.26.6"
 fi
 if [[ -z "${SOLR_IMAGE:-}" ]]; then
-  SOLR_IMAGE="${SOLR_VERSION:-8.11.2}"
+  SOLR_IMAGE="${SOLR_VERSION:-9.4.0}"
 fi
 if [[ "${SOLR_IMAGE}" != *":"* ]]; then
   SOLR_IMAGE="solr:${SOLR_IMAGE}"


### PR DESCRIPTION
This overrides #632 

Solr 9.4 has been released and fixes issues that caused incompatibility with the Solr Operator.
The smoke tests use Solr 8.11, so its safer to default to 9.4 so that we test both 8.11 and 9.4 more often.