### PR TITLE
Adding support for OpenShift securityContext

### DIFF
--- a/controllers/autodetect.go
+++ b/controllers/autodetect.go
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copied from grafana-operator
+// With the Apache License: https://github.com/grafana/grafana-operator/blob/master/LICENSE
+// See: https://github.com/grafana/grafana-operator/blob/master/controllers/autodetect/main.go
+// Package autodetect is for auto-detecting traits from the environment (platform, APIs, ...).
+package controllers
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+var _ AutoDetect = (*autoDetect)(nil)
+
+// AutoDetect provides an assortment of routines that auto-detect traits based on the runtime.
+type AutoDetect interface {
+	IsOpenshift() (bool, error)
+}
+
+type autoDetect struct {
+	dcl discovery.DiscoveryInterface
+}
+
+// New creates a new auto-detection worker, using the given client when talking to the current cluster.
+func NewAutodetect(restConfig *rest.Config) (AutoDetect, error) {
+	dcl, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		// it's pretty much impossible to get into this problem, as most of the
+		// code branches from the previous call just won't fail at all,
+		// but let's handle this error anyway...
+		return nil, err
+	}
+
+	return &autoDetect{
+		dcl: dcl,
+	}, nil
+}
+
+// Platform returns the detected platform this operator is running on. Possible values: Kubernetes, OpenShift.
+func (a *autoDetect) IsOpenshift() (bool, error) {
+	apiList, err := a.dcl.ServerGroups()
+	if err != nil {
+		return false, err
+	}
+
+	apiGroups := apiList.Groups
+	for i := range apiGroups {
+		if apiGroups[i].Name == "route.openshift.io" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -59,6 +59,7 @@ type SolrCloudReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	IsOpenShift bool
 }
 
 var useZkCRD bool
@@ -341,7 +342,7 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	var statefulSet *appsv1.StatefulSet
 	if !blockReconciliationOfStatefulSet {
 		// Generate StatefulSet that should exist
-		expectedStatefulSet := util.GenerateStatefulSet(instance, &newStatus, hostNameIpMap, reconcileConfigInfo, tls, security)
+		expectedStatefulSet := util.GenerateStatefulSet(instance, &newStatus, hostNameIpMap, reconcileConfigInfo, tls, security, r.IsOpenShift)
 
 		// Check if the StatefulSet already exists
 		statefulSetLogger := logger.WithValues("statefulSet", expectedStatefulSet.Name)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -109,6 +109,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Recorder: k8sManager.GetEventRecorderFor("solr-operator"),
+		IsOpenShift: false,
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
 	Expect((&SolrPrometheusExporterReconciler{

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -86,7 +86,7 @@ var (
 // replicas: the number of replicas for the SolrCloud instance
 // storage: the size of the storage for the SolrCloud instance (e.g. 100Gi)
 // zkConnectionString: the connectionString of the ZK instance to connect to
-func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCloudStatus, hostNameIPs map[string]string, reconcileConfigInfo map[string]string, tls *TLSCerts, security *SecurityConfig) *appsv1.StatefulSet {
+func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCloudStatus, hostNameIPs map[string]string, reconcileConfigInfo map[string]string, tls *TLSCerts, security *SecurityConfig, isOpenShift bool) *appsv1.StatefulSet {
 	terminationGracePeriod := int64(60)
 	shareProcessNamespace := false
 	var enableServiceLinks *bool
@@ -561,18 +561,19 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					ShareProcessNamespace:         &shareProcessNamespace,
 					EnableServiceLinks:            enableServiceLinks,
-					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: &defaultFSGroup,
-					},
-					Volumes:        solrVolumes,
-					InitContainers: initContainers,
-					HostAliases:    hostAliases,
-					Containers:     containers,
-					ReadinessGates: podReadinessGates,
+					SecurityContext:               &corev1.PodSecurityContext{},
+					Volumes:                       solrVolumes,
+					InitContainers:                initContainers,
+					HostAliases:                   hostAliases,
+					Containers:                    containers,
+					ReadinessGates:                podReadinessGates,
 				},
 			},
 			VolumeClaimTemplates: pvcs,
 		},
+	}
+	if !isOpenShift {
+		stateful.Spec.Template.Spec.SecurityContext.FSGroup = &defaultFSGroup
 	}
 	if solrCloud.UsesHeadlessService() {
 		stateful.Spec.Template.Spec.Subdomain = solrCloud.HeadlessServiceName()
@@ -610,7 +611,7 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 
 		if customPodOptions.PodSecurityContext != nil {
 			stateful.Spec.Template.Spec.SecurityContext = customPodOptions.PodSecurityContext
-			if stateful.Spec.Template.Spec.SecurityContext.FSGroup == nil {
+			if stateful.Spec.Template.Spec.SecurityContext.FSGroup == nil && !isOpenShift {
 				stateful.Spec.Template.Spec.SecurityContext.FSGroup = &defaultFSGroup
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -198,10 +198,27 @@ func main() {
 		}
 	}
 
+	// Fetch k8s api credentials and detect platform
+	restConfig := ctrl.GetConfigOrDie()
+
+	autodetect, err := controllers.NewAutodetect(restConfig)
+	if err != nil {
+		setupLog.Error(err, "failed to setup auto-detect routine")
+		os.Exit(1)
+	}
+
+	isOpenShift, err := autodetect.IsOpenshift()
+	setupLog.Info("autodetect", "isOpenShift", isOpenShift)
+	if err != nil {
+		setupLog.Error(err, "unable to detect the platform")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.SolrCloudReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("solr-operator"),
+		IsOpenShift: isOpenShift,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SolrCloud")
 		os.Exit(1)


### PR DESCRIPTION
Adding autodetection of solr-operator running on an OpenShift cluster to remove the default Solr fsGroup, and have an empty securityContext on OpenShift. Regular Kubernetes deployments have the same securityContext as before with fsGroup. 

I have successfully tested these changes in OpenShift Local and confirmed that an empty securityContext allows the solrcloud pod run on OpenShift. 

```yaml
spec:
  template:
    spec:
      securityContext: {}
```

Fixes #466