### PR TITLE
SOLR-16295: Modernize helm-chart project description

### DIFF
--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,7 +1,7 @@
 Apache Solr
 =============
 
-Solr is the blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
+Solr is the blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations.
 Other major features include: Kubernetes and docker integration; streaming; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,7 +1,7 @@
 Apache Solr
 =============
 
-Solr is the blazing fast, open source, multi-modal search platform built on Apache Lucene.  Its full-text, vector, analytics, and geospatial search power many of the world's largest organizations.
+Solr is the blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
 Other major features include: Kubernetes and docker integration; streaming; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,7 +1,7 @@
 Apache Solr
 =============
 
-Solr is the blazing-fast open source search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
+Solr is the blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
 Other major features include: Kubernetes and docker integration; streaming; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,10 +1,8 @@
 Apache Solr
 =============
 
-Apache Solr is the popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.
-
-Solr is highly reliable, scalable and fault tolerant, providing distributed indexing, replication and load-balanced querying, automated failover and recovery, centralized configuration and more.
-Solr powers the search and navigation features of many of the world's largest internet sites.
+Solr is the blazing fast, open source, multi-modal search platform built on Apache Lucene.  Its full-text, vector, and geospatial search power many of the world's largest organizations.
+Major features include: Kubernetes and docker integration; streaming and analytics; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).
 

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,8 +1,8 @@
 Apache Solr
 =============
 
-Solr is the blazing fast, open source, multi-modal search platform built on Apache Lucene.  Its full-text, vector, and geospatial search power many of the world's largest organizations.
-Major features include: Kubernetes and docker integration; streaming and analytics; and highlighting, faceting, and spellchecking.
+Solr is the blazing fast, open source, multi-modal search platform built on Apache Lucene.  Its full-text, vector, analytics, and geospatial search power many of the world's largest organizations.
+Other major features include: Kubernetes and docker integration; streaming; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).
 

--- a/helm/solr/README.md
+++ b/helm/solr/README.md
@@ -1,7 +1,7 @@
 Apache Solr
 =============
 
-Solr is the blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
+Solr is the blazing-fast open source search platform built on Apache Lucene. It powers full-text, vector, analytics, and geospatial search at many of the world's largest organizations
 Other major features include: Kubernetes and docker integration; streaming; and highlighting, faceting, and spellchecking.
 
 Documentation around using Apache Solr can be found on it's [official site](https://solr.apache.org).


### PR DESCRIPTION
# Description

Solr uses variations of the blurb below to describe itself on solr.apache.org, in the ref-guide, READMEs, etc:

> Solr is the popular, blazing-fast, open source enterprise search platform built on Apache Lucene [...]

This has served us well for years, but a few reasons call for a refresh:

1. Copies of this description have varied apart over time and need realigned
2. The description misses (or underplays) some of Solr's newer features (e.g. vector search)
3. Longer forms of the description emphasize features that aren't meaningful differentiators (e.g. XML-based APIs, scalability) in today's landscape.

# Solution

This PR (along with accompanying changes to the main repo and website) updates and unifies the language the project uses to describe itself.