### PR TITLE
Added ObservedGeneration to solrcloud status

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -1160,6 +1160,9 @@ type SolrCloudStatus struct {
 	// BackupRepositoriesAvailable lists the backupRepositories specified in the SolrCloud and whether they are available across all Pods.
 	// +optional
 	BackupRepositoriesAvailable map[string]bool `json:"backupRepositoriesAvailable,omitempty"`
+
+	// ObservedGeneration represents the most recent generation observed for this SolrCloud.
+	ObservedGeneration int64 `json:"observedGeneration"`
 }
 
 // SolrNodeStatus is the status of a solrNode in the cloud, with readiness status

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -15873,6 +15873,11 @@ spec:
                 description: InternalCommonAddress is the internal common http address
                   for all solr nodes
                 type: string
+              observedGeneration:
+                description: ObservedGeneration represents the most recent generation
+                  observed for this SolrCloud.
+                format: int64
+                type: integer
               podSelector:
                 description: PodSelector for SolrCloud pods, required by the HPA
                 type: string
@@ -16017,6 +16022,7 @@ spec:
                 type: object
             required:
             - internalCommonAddress
+            - observedGeneration
             - podSelector
             - readyReplicas
             - replicas

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -101,6 +101,8 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return reconcile.Result{}, err
 	}
 
+	reconcileGeneration := instance.ObjectMeta.Generation
+
 	changed := instance.WithDefaults(logger)
 	if changed {
 		logger.Info("Setting default settings for SolrCloud")
@@ -639,6 +641,7 @@ func (r *SolrCloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !reflect.DeepEqual(instance.Status, newStatus) {
+		newStatus.ObservedGeneration = reconcileGeneration
 		logger.Info("Updating SolrCloud Status", "status", newStatus)
 		oldInstance := instance.DeepCopy()
 		instance.Status = newStatus

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -16134,6 +16134,11 @@ spec:
                 description: InternalCommonAddress is the internal common http address
                   for all solr nodes
                 type: string
+              observedGeneration:
+                description: ObservedGeneration represents the most recent generation
+                  observed for this SolrCloud.
+                format: int64
+                type: integer
               podSelector:
                 description: PodSelector for SolrCloud pods, required by the HPA
                 type: string
@@ -16278,6 +16283,7 @@ spec:
                 type: object
             required:
             - internalCommonAddress
+            - observedGeneration
             - podSelector
             - readyReplicas
             - replicas


### PR DESCRIPTION
Implemented #650 

Have added observed generation to the status of the solrcloud CR to track the transition of the solrcloud.