### PR TITLE
fix: do not return metrics for prom-exporter probes re-fix (#694)

### DIFF
--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -208,7 +208,7 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 		HTTPGet: &corev1.HTTPGetAction{
 			Scheme: corev1.URISchemeHTTP,
 			// TODO: When 9.0 is the minimum supported version, this can be "/-/healthy"
-			Path: "/metrics?names[]=",
+			Path: "/metrics?name[]=",
 			Port: intstr.FromInt(SolrMetricsPort),
 		},
 	}


### PR DESCRIPTION
a re-fix for #694 as the used query parameter has to be 'name[]' instead of name**s**[]

according to the used HTTPServer code (0.16.0 in Solr 9 or 0.2.0 in Solr 8.11)
https://github.com/prometheus/client_java/blob/ed0d7ae3b57a3986f6531d1a37db031a331227e6/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java#L153