### PR TITLE
Clarify lack of 'standalone' Solr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/apache/solr-operator)](https://hub.docker.com/r/apache/solr-operator/)
 [![Slack](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://kubernetes.slack.com/messages/solr-operator)
 
-The __[Solr Operator](https://solr.apache.org/operator/)__ is the official way of managing an Apache Solr ecosystem within Kubernetes.
+The __[Solr Operator](https://solr.apache.org/operator/)__ is the official way of managing Apache SolrCloud deployments within Kubernetes.
 It is built on top of the [Kube Builder](https://github.com/kubernetes-sigs/kubebuilder) framework.
 Please visit the [official site](https://solr.apache.org/operator/) for more information.
 

--- a/docs/solr-cloud/README.md
+++ b/docs/solr-cloud/README.md
@@ -22,7 +22,8 @@ Child Pages:
 - [Managed Updates](managed-updates.md)
 - [Scaling](scaling.md)
 
-The Solr Operator supports creating and managing Solr Clouds.
+The Solr Operator supports creating and managing Solr Clouds clusters via its 'solrcloud' resource.
+(Note: running Solr in "standalone" mode is not supported.)
 
 This page outlines how to create, update and delete a SolrCloud in Kubernetes.
 

--- a/docs/solr-cloud/solr-cloud-crd.md
+++ b/docs/solr-cloud/solr-cloud-crd.md
@@ -171,9 +171,9 @@ Please refer to the [SolrBackup documentation](../solr-backup) for more informat
 
 ## Zookeeper Reference
 
-Solr Clouds require an Apache Zookeeper to connect to.
+All SolrCloud resources run Solr in "cloud" mode, and require access to an Apache ZooKeeper cluster for state-management.
 
-The Solr operator gives a few options.
+The Solr operator gives a few options for ZooKeeper access:
 
 - Connecting to an already running zookeeper ensemble via [connection strings](#zk-connection-info)
 - [Spinning up a provided](#provided-instance) Zookeeper Ensemble in the same namespace via the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator)


### PR DESCRIPTION
The Solr-operator only has support for running Solr in "cloud" mode, as evidenced by the required ZK coordinates and even the name of the 'solrcloud' custom resource.  But there are few explicit mentions of this in the README or project docs.

This commit tweaks the docs to make this slightly more explicit.