### PR TITLE
Allow imagePullSecret in operator helm chart

### DIFF
--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -105,7 +105,7 @@ annotations:
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/692
     - kind: added
-      description: 'imagePullSecret' now used when fetching operator image, if provided.
+      description: "'imagePullSecret' now used when fetching operator image, if provided."
       links:
         - name: Github Issue
           url: https://github.com/apache/solr-operator/issues/718

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -53,6 +53,7 @@ annotations:
     url: https://dist.apache.org/repos/dist/release/solr/KEYS
   # Add change log for a single release here.
   # Allowed syntax is described at: https://artifacthub.io/docs/topics/annotations/helm/#example
+  # 'kind' accepts values: "added", "changed", "deprecated", "removed", "fixed" and "security"
   artifacthub.io/changes: |
     - kind: fixed
       description: gen-pkcs12-keystore initContainer now supports 'ca.crt'-less TLS secrets
@@ -103,6 +104,13 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/682
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/692
+    - kind: added
+      description: 'imagePullSecret' now used when fetching operator image, if provided.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/718
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/734
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.9.0-prerelease

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -174,6 +174,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.repository | string | `"apache/solr-operator"` | The repository of the Solr Operator image |
 | image.tag | string | `"v0.9.0-prerelease"` | The tag/version of the Solr Operator to run |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.imagePullSecret | string | `""` | PullSecret for the Solr Operator image |
 | fullnameOverride | string | `""` | A custom name for the Solr Operator Deployment |
 | nameOverride | string | `""` |  |
 | replicaCount | int | `1` | The number of Solr Operator pods to run |

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" 
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.image.imagePullSecret }}
+        imagePullSecret: {{ .Values.image.imagePullSecret }}
+        {{- end }}
         args:
         {{- if or (index .Values "zookeeper-operator" "install") (index .Values "zookeeper-operator" "use") }}
         - -zk-operator=true

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -23,6 +23,7 @@ image:
   repository: apache/solr-operator
   tag: v0.9.0-prerelease
   pullPolicy: IfNotPresent
+  imagePullSecret: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Operator users may host the image in their own repositories, protected by authentication.  Accept an imagePullSecret to facilitate these use cases.

Closes #718 