### PR TITLE
fix(solr-zk) Switch from zkcli to solr zk command line

### DIFF
--- a/controllers/solrcloud_controller_basic_auth_test.go
+++ b/controllers/solrcloud_controller_basic_auth_test.go
@@ -352,9 +352,9 @@ func expectBasicAuthConfigOnPodTemplateWithGomega(g Gomega, solrCloud *solrv1bet
 func expectPutSecurityJsonInZkCmd(g Gomega, expInitContainer *corev1.Container) {
 	g.Expect(expInitContainer).To(Not(BeNil()), "Didn't find the setup-zk InitContainer in the sts!")
 	expCmd := "solr zk cp zk:/security.json /tmp/current_security.json >/dev/null 2>&1;  " +
-		"GET_CURRENT_SECURITY_JSON_EXIT_CODE=$?if [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 0 ]; then " +
+		"GET_CURRENT_SECURITY_JSON_EXIT_CODE=$?; if [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 0 ]; then " +
 		"if [ ! -s /tmp/current_security.json ] || grep -q '^{}$' /tmp/current_security.json ]; then  " +
-		"echo $SECURITY_JSON > /tmp/security.json;  solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
+		"echo $SECURITY_JSON > /tmp/security.json; solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
 		" echo 'Blank security.json found. Put new security.json in ZK'; fi; elif [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 1 ]; then " +
 		" echo $SECURITY_JSON > /tmp/security.json; solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
 		" echo 'No security.json found. Put new security.json in ZK'; fi"

--- a/controllers/util/solr_security_util.go
+++ b/controllers/util/solr_security_util.go
@@ -238,10 +238,10 @@ func addHostHeaderToProbe(httpGet *corev1.HTTPGetAction, host string) {
 
 func cmdToPutSecurityJsonInZk() string {
 	cmd := " solr zk cp zk:/security.json /tmp/current_security.json >/dev/null 2>&1; " +
-		" GET_CURRENT_SECURITY_JSON_EXIT_CODE=$?" +
+		" GET_CURRENT_SECURITY_JSON_EXIT_CODE=$?; " +
 		"if [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 0 ]; then " + // JSON already exists
 		"if [ ! -s /tmp/current_security.json ] || grep -q '^{}$' /tmp/current_security.json ]; then " + // File doesn't exist, is empty, or is just '{}'
-		" echo $SECURITY_JSON > /tmp/security.json; " +
+		" echo $SECURITY_JSON > /tmp/security.json;" +
 		" solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
 		" echo 'Blank security.json found. Put new security.json in ZK'; " +
 		"fi; " + // TODO: Consider checking a diff and still applying over the top

--- a/controllers/util/solr_security_util.go
+++ b/controllers/util/solr_security_util.go
@@ -237,10 +237,20 @@ func addHostHeaderToProbe(httpGet *corev1.HTTPGetAction, host string) {
 }
 
 func cmdToPutSecurityJsonInZk() string {
-	scriptsDir := "/opt/solr/server/scripts/cloud-scripts"
-	cmd := " ZK_SECURITY_JSON=$(%s/zkcli.sh -zkhost ${ZK_HOST} -cmd get /security.json || echo 'failed-to-get-security.json'); "
-	cmd += "if [ ${#ZK_SECURITY_JSON} -lt 3 ]; then echo $SECURITY_JSON > /tmp/security.json; %s/zkcli.sh -zkhost ${ZK_HOST} -cmd putfile /security.json /tmp/security.json; echo \"put security.json in ZK\"; fi"
-	return fmt.Sprintf(cmd, scriptsDir, scriptsDir)
+	cmd := " solr zk cp zk:/security.json /tmp/current_security.json >/dev/null 2>&1; " +
+		" GET_CURRENT_SECURITY_JSON_EXIT_CODE=$?" +
+		"if [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 0 ]; then " + // JSON already exists
+		"if [ ! -s /tmp/current_security.json ] || grep -q '^{}$' /tmp/current_security.json ]; then " + // File doesn't exist, is empty, or is just '{}'
+		" echo $SECURITY_JSON > /tmp/security.json; " +
+		" solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
+		" echo 'Blank security.json found. Put new security.json in ZK'; " +
+		"fi; " + // TODO: Consider checking a diff and still applying over the top
+		"elif [ ${GET_CURRENT_SECURITY_JSON_EXIT_CODE} -eq 1 ]; then " + // JSON doesn't exist, but not other error types
+		" echo $SECURITY_JSON > /tmp/security.json;" +
+		" solr zk cp /tmp/security.json zk:/security.json >/dev/null 2>&1; " +
+		" echo 'No security.json found. Put new security.json in ZK'; " +
+		"fi"
+	return cmd
 }
 
 // Add auth data to the supplied Context using secrets already resolved (stored in the SecurityConfig)

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,11 @@ export PATH="$PATH:$GOPATH/bin" # You likely want to add this line to your ~/.ba
 make install-dependencies
 ```
 
+Note: if you have previously installed/older versions of dependencies, you can first clear these dependencies with:
+```bash
+make clean
+```
+
 ## Build the Solr CRDs
 
 If you have changed anything in the [APIs directory](/api/v1beta1), you will need to run the following command to regenerate all Solr CRDs.

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -103,6 +103,15 @@ annotations:
           url: https://github.com/apache/solr-operator/issues/682
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/692
+    - kind: fixed
+      description: setup-zk initContainer now gracefully handles absent security.json on initial upload.
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/720
+        - name: Additional Github Issue
+          url: https://github.com/apache/solr-operator/issues/731
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/738
   artifacthub.io/images: |
     - name: solr-operator
       image: apache/solr-operator:v0.9.0-prerelease

--- a/tests/e2e/solrcloud_security_json_test.go
+++ b/tests/e2e/solrcloud_security_json_test.go
@@ -35,7 +35,7 @@ var _ = FDescribe("E2E - SolrCloud - Security JSON", func() {
 	})
 
 	JustBeforeEach(func(ctx context.Context) {
-		By("generating the security.json secret")
+		By("generating the security.json secret and basic auth secret")
 		generateSolrSecuritySecret(ctx, solrCloud)
 		generateSolrBasicAuthSecret(ctx, solrCloud)
 

--- a/tests/e2e/solrcloud_security_json_test.go
+++ b/tests/e2e/solrcloud_security_json_test.go
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e
+
+import (
+	"context"
+	solrv1beta1 "github.com/apache/solr-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = FDescribe("E2E - SolrCloud - Security JSON", func() {
+	var (
+		solrCloud *solrv1beta1.SolrCloud
+	)
+
+	BeforeEach(func() {
+		solrCloud = generateBaseSolrCloudWithSecurityJSON(1)
+	})
+
+	JustBeforeEach(func(ctx context.Context) {
+		By("generating the security.json secret")
+		generateSolrSecuritySecret(ctx, solrCloud)
+		generateSolrBasicAuthSecret(ctx, solrCloud)
+
+		By("creating the SolrCloud")
+		Expect(k8sClient.Create(ctx, solrCloud)).To(Succeed())
+
+		DeferCleanup(func(ctx context.Context) {
+			cleanupTest(ctx, solrCloud)
+		})
+
+		By("Waiting for the SolrCloud to come up healthy")
+		solrCloud = expectSolrCloudToBeReady(ctx, solrCloud)
+
+		By("creating a first Solr Collection")
+		createAndQueryCollection(ctx, solrCloud, "basic", 1, 1)
+	})
+
+	FContext("Provided Zookeeper", func() {
+		BeforeEach(func() {
+			solrCloud.Spec.ZookeeperRef = &solrv1beta1.ZookeeperRef{
+				ProvidedZookeeper: &solrv1beta1.ZookeeperSpec{
+					Replicas:  pointer.Int32(1),
+					Ephemeral: &solrv1beta1.ZKEphemeral{},
+				},
+			}
+		})
+
+		// All testing will be done in the "JustBeforeEach" logic, no additional tests required here
+		FIt("Starts correctly", func(ctx context.Context) {})
+	})
+})

--- a/tests/e2e/test_utils_test.go
+++ b/tests/e2e/test_utils_test.go
@@ -581,6 +581,9 @@ func generateBaseSolrCloud(replicas int) *solrv1beta1.SolrCloud {
 	}
 }
 
+// Uses default password from docs : SolrRocks
+// The hash is generated as: base64(sha256(sha256(salt+password))) base64(salt))
+// See https://solr.apache.org/guide/solr/latest/deployment-guide/basic-authentication-plugin.html
 func generateSolrSecuritySecret(ctx context.Context, solrCloud *solrv1beta1.SolrCloud) {
 	securityJsonSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This is primarily intended as a fix for https://github.com/apache/solr-operator/issues/731 and https://github.com/apache/solr-operator/issues/720.

This PR switches the setup-zk initcontainer from using the zkcli to `solr zk ...`. The zkcli is deprecated and will be removed in Solr 10. Also, this PR fixes bootstrapping with a custom security.json that was broken in v9.7. 

Please see comments in implementation.

I've updated the unit tests, and added an integration test for bootstrapping with a custom security.json. Below is the output of running that test:

```
make e2e-tests TEST_FILTER="E2E - SolrCloud - Security JSON"
...



Will run 1 of 28 specs
Running in parallel across 3 processes
SSSSSSSSSSSSSSSSSSSSSSSSSSS•

Ran 1 of 28 Specs in 82.823 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 27 Skipped


Ginkgo ran 1 suite in 1m33.993254375s
Test Suite Passed

********************
``` 