### PR TITLE
Workaround dist.apache.org download restrictions

### DIFF
--- a/hack/release/upload/upload_crds.sh
+++ b/hack/release/upload/upload_crds.sh
@@ -95,7 +95,7 @@ echo "Pulling CRDs from the staged url and uploading to release location ${CRDS_
     cd "${TMP_DIR}"
 
     # Download CRD files from the staged location
-    wget -r -np -nH -nd --level=1 -A "*.yaml*" "${RELEASE_URL}/crds/"
+    wget -e robots=off -r -np -nH -nd --level=1 -A "*.yaml*" "${RELEASE_URL}/crds/"
 
     rm -f robots.txt*
 

--- a/hack/release/upload/upload_helm.sh
+++ b/hack/release/upload/upload_helm.sh
@@ -96,7 +96,7 @@ echo "Pulling Helm chart from the staged url and uploading to release Helm repo.
     cd "${TMP_DIR}"
 
     # Pull Helm charts from staged location
-    wget -r -np -nH -nd --level=1 -A "*.tgz*" "${RELEASE_URL}/helm-charts"
+    wget -e robots=off -r -np -nH -nd --level=1 -A "*.tgz*" "${RELEASE_URL}/helm-charts"
 
     rm -f robots.txt*
 


### PR DESCRIPTION
After a "passing" RC, the wizard has RMs download the CRDs and helm charts from a 'staging' area on dist.apache.org and then upload them to the final location.  We have scripts to do this, but these were broken recently when dist.apache.org changed its robots.txt to disallow unknown "crawlers".

This commit gets our scripting working again by tweaking a `wget` invocation to not strictly obey the robots.txt for dist.apache.org, which likely isn't intended for restricting foundation-internal usecases such as ours.