### PR TITLE
Make ingress hostname configurable

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -540,6 +540,11 @@ type ExternalAddressability struct {
 	// +optional
 	AdditionalDomainNames []string `json:"additionalDomainNames,omitempty"`
 
+	// Provide a custom host / dns name for the ingress resource that gets created.
+	// This uses the DomainName, so you only specify the actual Host in front of it.
+	// e.g. given.domain.name.com -> my-solr-ingress.given.domain.name.com
+	HostName string `json:"hostName,omitempty"`
+
 	// NodePortOverride defines the port to have all Solr node service(s) listen on and advertise itself as if advertising through an Ingress or LoadBalancer.
 	// This overrides the default usage of the podPort.
 	//
@@ -1456,6 +1461,12 @@ func (sc *SolrCloud) ExternalCommonUrl(domainName string, withPort bool) (url st
 		// Ingress does not require a port, since the port is whatever the ingress is listening on (80 and 443)
 		url += sc.CommonPortSuffix(true)
 	}
+	return url
+}
+
+// ExternalHostNameUrl assumes we are using Ingress as the Addressability method
+func (sc *SolrCloud) ExternalHostNameUrl(domainName string, withPort bool) (url string) {
+	url = fmt.Sprintf("%s.%s", sc.Spec.SolrAddressability.External.HostName, domainName)
 	return url
 }
 

--- a/config/crd/bases/solr.apache.org_solrbackups.yaml
+++ b/config/crd/bases/solr.apache.org_solrbackups.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrbackups.solr.apache.org

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrclouds.solr.apache.org
@@ -9899,6 +9899,12 @@ spec:
                           The number of services this affects could range from 1 (a headless service for ExternalDNS) to the number of Solr pods your cloud contains (individual node services for Ingress/LoadBalancer).
                           Defaults to false.
                         type: boolean
+                      hostName:
+                        description: |-
+                          Provide a custom host / dns name for the ingress resource that gets created.
+                          This uses the DomainName, so you only specify the actual Host in front of it.
+                          e.g. given.domain.name.com -> my-solr-ingress.given.domain.name.com
+                        type: string
                       ingressTLSTermination:
                         description: |-
                           IngressTLSTermination tells the SolrCloud Ingress to terminate TLS on incoming connections.

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrprometheusexporters.solr.apache.org

--- a/docs/solr-cloud/solr-cloud-crd.md
+++ b/docs/solr-cloud/solr-cloud-crd.md
@@ -132,6 +132,7 @@ Under `SolrCloud.Spec.solrAddressability`:
   Currently available options are [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/) and [`ExternalDNS`](https://github.com/kubernetes-sigs/external-dns).
   The goal is to support more methods in the future, such as LoadBalanced Services.
   - **`domainName`** - (Required) The primary domain name to open your cloud endpoints on. If `useExternalAddress` is set to `true`, then this is the domain that will be used in Solr Node names.
+  - **`hostName`** - (Optional) Provide a custom host / dns name for the ingress resource that gets created. This uses the `domainName`, so you only specify the actual Host in front of it, e.g. k8s.solr.cloud -> solr-ingress.k8s.solr.cloud
   - **`additionalDomainNames`** - You can choose to listen on additional domains for each endpoint, however Solr will not register itself under these names.
   - **`useExternalAddress`** - Use the external address to advertise the SolrNode. If a domain name is required for the chosen external `method`, then the one provided in `domainName` will be used. \
     This can not be set to `true` when **`hideNodes`** is set to `true` or **`ingressTLSTermination`** is used.

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrbackups.solr.apache.org
@@ -275,7 +275,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrclouds.solr.apache.org
@@ -10157,6 +10157,12 @@ spec:
                           The number of services this affects could range from 1 (a headless service for ExternalDNS) to the number of Solr pods your cloud contains (individual node services for Ingress/LoadBalancer).
                           Defaults to false.
                         type: boolean
+                      hostName:
+                        description: |-
+                          Provide a custom host / dns name for the ingress resource that gets created.
+                          This uses the DomainName, so you only specify the actual Host in front of it.
+                          e.g. given.domain.name.com -> my-solr-ingress.given.domain.name.com
+                        type: string
                       ingressTLSTermination:
                         description: |-
                           IngressTLSTermination tells the SolrCloud Ingress to terminate TLS on incoming connections.
@@ -17870,7 +17876,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    operator.solr.apache.org/version: v0.10.0-prerelease
+    operator.solr.apache.org/version: v0.11.0-prerelease
     argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.16.4
   name: solrprometheusexporters.solr.apache.org

--- a/tests/scripts/manage_e2e_tests.sh
+++ b/tests/scripts/manage_e2e_tests.sh
@@ -81,7 +81,8 @@ fi
 if [[ "${SOLR_IMAGE}" != *":"* ]]; then
   SOLR_IMAGE="solr:${SOLR_IMAGE}"
 fi
-IFS=$'\036'; RAW_GINKGO=(${RAW_GINKGO:-}); unset IFS
+#IFS=$'\036'; RAW_GINKGO=(${RAW_GINKGO:-}); unset IFS
+IFS=$'\036'; RAW_GINKGO=(${RAW_GINKGO[@]:-()}); unset IFS
 
 CLUSTER_NAME="$(echo "solr-op-e2e-${OPERATOR_IMAGE##*:}-k-${KUBERNETES_VERSION}-s-${SOLR_IMAGE##*:}"  | tr '[:upper:]' '[:lower:]' | sed "s/snapshot/snap/" | sed "s/prerelease/pre/")"
 export CLUSTER_NAME

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ package version
 
 var (
 	// Version information for the Solr Operator
-	Version       = "v0.10.0"
+	Version       = "v0.11.0"
 	VersionSuffix = "prerelease"
 	BuildTime     string
 	GitSHA        string


### PR DESCRIPTION
This PR addresses the possibility to add an `hostName` to the ingress configuration of a given solrcloud instance as described in #667.

The change is quit simple. Unfortunately, the `make prepare` step failed for me at the `fetch-licenses-list` step, so the `dependency_licenses.csv` stays empty in my case.

```
make: *** [fetch-licenses-list] Error 1

```

To make the e2e-tests start / work, I also needed to change the `RAW_GINKGO` command. Not sure if that is an issue only on my machine.

Happy for any feedback!