### PR TITLE
Prevent RAW_GINKGO unset error in e2e tests

### DIFF
--- a/tests/scripts/manage_e2e_tests.sh
+++ b/tests/scripts/manage_e2e_tests.sh
@@ -130,7 +130,9 @@ function run_tests() {
       GINKGO_PARAMS+=("${param}" "${!envName}")
     fi
   done
-  GINKGO_PARAMS+=("${RAW_GINKGO[@]}")
+  if [[ -n "${RAW_GINKGO:-}" ]]; then
+    GINKGO_PARAMS+=("${RAW_GINKGO[@]}")
+  fi
 
   GINKGO_EDITOR_INTEGRATION=true ginkgo --randomize-all "${GINKGO_PARAMS[@]}" "${REPO_DIR}"/tests/e2e/...
 


### PR DESCRIPTION
Not all environments set particular `RAW_GINKGO` args, causing `make e2e-tests` to fail with an "unset variable" related error.

This commit tweaks our `manage_e2e_tests.sh` script to guard against this case.