### PR TITLE
Use supported Solr version in examples

### DIFF
--- a/example/test_solrcloud.yaml
+++ b/example/test_solrcloud.yaml
@@ -28,7 +28,7 @@ spec:
               storage: "5Gi"
   replicas: 3
   solrImage:
-    tag: 8.7.0
+    tag: "8.11"
   solrJavaMem: "-Xms1g -Xmx3g"
   solrModules:
     - jaegertracer-configurator

--- a/example/test_solrcloud_backuprepos.yaml
+++ b/example/test_solrcloud_backuprepos.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   replicas: 1
   solrImage:
-    tag: 8.10
+    tag: "8.11"
   backupRepositories:
     # "Volume" repositories store backup data in a Kubernetes volume.
     - name: "volume_repository_1"

--- a/example/test_solrcloud_private_repo.yaml
+++ b/example/test_solrcloud_private_repo.yaml
@@ -21,5 +21,5 @@ spec:
   replicas: 3
   solrImage:
     repository: myprivate-repo.jfrog.io/solr
-    tag: 8.7.0
+    tag: "8.11"
     imagePullSecret: "k8s-docker-registry-secret"

--- a/example/test_solrcloud_toleration_example.yaml
+++ b/example/test_solrcloud_toleration_example.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   replicas: 1
   solrImage:
-    tag: 8.7.0
+    tag: "8.11"
   customSolrKubeOptions:
     podOptions:
       nodeSelector:

--- a/example/test_solrprometheusexporter.yaml
+++ b/example/test_solrprometheusexporter.yaml
@@ -23,4 +23,4 @@ spec:
       name: "example"
   numThreads: 4
   image:
-    tag: 8.7.0
+    tag: "8.11"


### PR DESCRIPTION
Several examples referenced the Solr 8.7, and other versions outside the currently supported range (which currently starts at 8.11).