### PR TITLE
Configure operator logging in helm chart

### DIFF
--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -148,7 +148,18 @@ The final image will only contain the solr-operator binary and necessary License
 * **--health-probe-bind-address=** The address to bind the health probe servlet on.
   If only a port is provided (e.g. `:8081`), then the metrics server will respond to requests with any Host header.
   (defaults to _:8081_)
-                        
+
+* **--zap-devel** Enables development mode. 
+  Changes logging to `console` encoder and `debug` level. (_true_ | _false_, defaults to _false_)
+
+* **--zap-log-level** Overrides the log level. 
+  Can be one of `debug`, `info`, `error`, or any integer value > 0 for custom verbosity. (_string_, defaults to _empty_)
+
+* **--zap-encoder** Overrides the log format.
+  Use `console` or `json`. (_string_, defaults to _empty_)
+
+* **--zap-stacktrace-level** Overrides the level for stack trace logging. (_string_, defaults to _empty_)
+
 ## Client Auth for mTLS-enabled Solr clusters
 
 For SolrCloud instances that run with mTLS enabled (see `spec.solrTLS.clientAuth`), the operator needs to supply a trusted certificate when making API calls to the Solr pods it is managing.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -125,6 +125,12 @@ _Note that the Helm chart version does not contain a `v` prefix, which the downl
 
 ## Upgrade Warnings and Notes
 
+### v0.10.0
+- **Logging now defaults to JSON format**
+  The new default for CLI flag `--zap-devel` is now `false`, causing log encoding to be `json` and log level to be `info`.
+  There is a new helm value `development` that can be set to `true` to switch to `console` encoding and `debug` level
+  that was the default in previous versions.
+
 ### v0.8.0
 - **The minimum supported Solr version is now 8.11**
   If you are unable to use a newer version of Solr, please install the `v0.7.1` version of the Solr Operator.

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -60,8 +60,13 @@ annotations:
       links:
         - name: Github PR
           url: https://github.com/apache/solr-operator/pull/774
+    - kind: changed
+      description: The default logging format is now `json`, and default log level is `info`.
+      links:
+        - name: Github PR
+          url: https://github.com/apache/solr-operator/pull/779
     - kind: added
-      description: Ability to configure log encoder, level and stacktrace level
+      description: Ability to configure `development` mode as well as log encoder, log level and stacktrace log level
       links:
         - name: Github Issue
           url: https://github.com/apache/solr-operator/issues/778

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -56,6 +56,11 @@ annotations:
   # 'kind' accepts values: "added", "changed", "deprecated", "removed", "fixed" and "security"
   artifacthub.io/changes: |
     - kind: added
+      description: Ability to configure log encoder, level and stacktrace level
+      links:
+        - name: Github Issue
+          url: https://github.com/apache/solr-operator/issues/778
+    - kind: added
       description: Addition 1
       links:
         - name: Github Issue

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -191,6 +191,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | tolerations | []object |  | Specify a list of Kubernetes tolerations for the Solr Operator pod |
 | priorityClassName | string | `""` | Give a priorityClassName for the Solr Operator pod |
 | sidecarContainers | []object |  | An optional list of additional containers to run along side the Solr Operator in its pod |
+| logger.devel | boolean | `false` | Enable development mode for the Solr Operator logger. This will log at the debug level with the console encoder. Default is `false` which logs at `info` level with `json` encoder. |
+| logger.level | string |  | Overrides the log level. Can be one of `debug`, `info`, `error`, or any integer value > 0 which corresponds to custom debug levels of increasing verbosity|
+| logger.encoder | string | | Overrides the log format. Use `console` or `json`. |
+| logger.stacktraceLevel | string | | Overrides the level for stackTrace logging. |
 
 ### Configuring the Zookeeper Operator
 

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -191,10 +191,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | tolerations | []object |  | Specify a list of Kubernetes tolerations for the Solr Operator pod |
 | priorityClassName | string | `""` | Give a priorityClassName for the Solr Operator pod |
 | sidecarContainers | []object |  | An optional list of additional containers to run along side the Solr Operator in its pod |
-| logger.devel | boolean | `false` | Enable development mode for the Solr Operator logger. This will log at the debug level with the console encoder. Default is `false` which logs at `info` level with `json` encoder. |
 | logger.level | string |  | Overrides the log level. Can be one of `debug`, `info`, `error`, or any integer value > 0 which corresponds to custom debug levels of increasing verbosity|
 | logger.encoder | string | | Overrides the log format. Use `console` or `json`. |
 | logger.stacktraceLevel | string | | Overrides the level for stackTrace logging. |
+| development | boolean | `false` | Enables development mode. This will change logging to `console` encoder and `debug` level |
 
 ### Configuring the Zookeeper Operator
 

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -78,6 +78,16 @@ spec:
         {{- else }}
         - "--leader-elect=false"
         {{- end }}
+        - --zap-devel={{ .Values.logger.devel }}
+        {{- if .Values.logger.encoder }}
+        - --zap-encoder={{ .Values.logger.encoder }}
+        {{- end }}
+        {{- if .Values.logger.level }}
+        - --zap-log-level={{ .Values.logger.level }}
+        {{- end }}
+        {{- if .Values.logger.stacktraceLevel }}
+        - --zap-stacktrace-level={{ .Values.logger.stacktraceLevel }}
+        {{- end }}
 
         env:
           - name: POD_NAMESPACE

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         {{- else }}
         - "--leader-elect=false"
         {{- end }}
-        - --zap-devel={{ .Values.logger.devel }}
+        - --zap-devel={{ .Values.development }}
         {{- if .Values.logger.encoder }}
         - --zap-encoder={{ .Values.logger.encoder }}
         {{- end }}

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -19,6 +19,14 @@
 
 replicaCount: 1
 
+logger:
+  # devel=true sets encoder=console, level=debug, stacktrace-level=warn
+  # devel=false sets encoder=json, level=info, stacktrace-level=error
+  devel: false
+  #encoder: json
+  #level: error
+  #stacktraceLevel: error
+
 image:
   repository: apache/solr-operator
   tag: v0.10.0-prerelease

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -19,10 +19,12 @@
 
 replicaCount: 1
 
-logger:
-  # devel=true sets encoder=console, level=debug, stacktrace-level=warn
-  # devel=false sets encoder=json, level=info, stacktrace-level=error
-  devel: false
+# Development mode configures certain settings for convenient development.
+# When 'true', logging will use: encoder=console, level=debug, stacktrace-level=warn
+development: false
+
+# These are default logger settings in production mode, but can be overridden here
+logger: {}
   #encoder: json
   #level: error
   #stacktraceLevel: error


### PR DESCRIPTION
Adds this to `values.yaml`:

```
# Development mode configures certain settings for convenient development.
# When 'true', logging will use: encoder=console, level=debug, stacktrace-level=warn
development: false

# These are default logger settings in production mode, but can be overridden here
logger: {}
  #encoder: json
  #level: error
  #stacktraceLevel: error
```

Docs:
<img width="974" alt="Skjermbilde 2025-04-03 kl  19 23 11" src="https://github.com/user-attachments/assets/7f023577-929a-476a-81db-bf8f221ccf51" />

**Note** that today zap "Development" mode has been the default, but this PR changes that to `false`, triggering production mode by default, and thus also log-level INFO and encoding to JSON. This is perhaps a bit much change in a minor version even if it is easy for users to tailor it. At the same time it feels wrong that development is the default mode. We could keep the default of development=true and change it to false in v1.0?

Fixes #778